### PR TITLE
Add NPC teleport GUI with configurable spawn locations

### DIFF
--- a/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/ElytriaEssentials.java
+++ b/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/ElytriaEssentials.java
@@ -1,13 +1,16 @@
 package me.luisgamedev.elytriaEssentials;
 
 import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.Bukkit;
+import org.bukkit.plugin.PluginManager;
 
 public final class ElytriaEssentials extends JavaPlugin {
 
     @Override
     public void onEnable() {
-        // Plugin startup logic
-
+        saveDefaultConfig();
+        PluginManager pm = Bukkit.getPluginManager();
+        pm.registerEvents(new TeleportListener(this), this);
     }
 
     @Override

--- a/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/TeleportListener.java
+++ b/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/TeleportListener.java
@@ -1,0 +1,135 @@
+package me.luisgamedev.elytriaEssentials;
+
+import net.kyori.adventure.text.Component;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.player.PlayerInteractEntityEvent;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.metadata.MetadataValue;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class TeleportListener implements Listener {
+    private final ElytriaEssentials plugin;
+    private final Map<String, Location> locations = new HashMap<>();
+    private final String npcId;
+    private final Component menuTitle = Component.text("Teleport Locations");
+
+    public TeleportListener(ElytriaEssentials plugin) {
+        this.plugin = plugin;
+        FileConfiguration config = plugin.getConfig();
+        npcId = config.getString("npc-id", "teleporter");
+        loadLocation("desert", config);
+        loadLocation("feyforest", config);
+        loadLocation("oaklands", config);
+        loadLocation("frostland", config);
+    }
+
+    private void loadLocation(String key, FileConfiguration config) {
+        ConfigurationSection section = config.getConfigurationSection("locations." + key);
+        if (section == null) {
+            return;
+        }
+        String worldName = section.getString("world", "world");
+        World world = Bukkit.getWorld(worldName);
+        if (world == null) {
+            return;
+        }
+        double x = section.getDouble("x");
+        double y = section.getDouble("y");
+        double z = section.getDouble("z");
+        locations.put(key, new Location(world, x, y, z));
+    }
+
+    @EventHandler
+    public void onNpcInteract(PlayerInteractEntityEvent event) {
+        if (event.getHand() != EquipmentSlot.HAND) {
+            return;
+        }
+        Entity entity = event.getRightClicked();
+        if (!entity.hasMetadata("npc-id")) {
+            return;
+        }
+        List<MetadataValue> data = entity.getMetadata("npc-id");
+        for (MetadataValue value : data) {
+            if (npcId.equals(value.asString())) {
+                event.setCancelled(true);
+                openMenu(event.getPlayer());
+                break;
+            }
+        }
+    }
+
+    private void openMenu(Player player) {
+        Inventory inv = Bukkit.createInventory(null, 45, menuTitle);
+        ItemStack glass = new ItemStack(Material.GRAY_STAINED_GLASS_PANE);
+        ItemMeta glassMeta = glass.getItemMeta();
+        glassMeta.displayName(Component.text(" "));
+        glass.setItemMeta(glassMeta);
+
+        for (int i = 0; i < inv.getSize(); i++) {
+            int row = i / 9;
+            int col = i % 9;
+            if (row == 0 || row == 4 || col == 0 || col == 8) {
+                inv.setItem(i, glass);
+            }
+        }
+
+        inv.setItem(22, createItem(Material.SAND, "Desert"));
+        inv.setItem(23, createItem(Material.MOSS_BLOCK, "Feyforest"));
+        inv.setItem(31, createItem(Material.OAK_SAPLING, "Oaklands"));
+        inv.setItem(32, createItem(Material.ICE, "Frostland"));
+
+        player.openInventory(inv);
+    }
+
+    private ItemStack createItem(Material material, String name) {
+        ItemStack item = new ItemStack(material);
+        ItemMeta meta = item.getItemMeta();
+        meta.displayName(Component.text(name));
+        item.setItemMeta(meta);
+        return item;
+    }
+
+    @EventHandler
+    public void onInventoryClick(InventoryClickEvent event) {
+        if (!(event.getWhoClicked() instanceof Player player)) {
+            return;
+        }
+        if (!event.getView().title().equals(menuTitle)) {
+            return;
+        }
+        if (event.getClickedInventory() == null || event.getRawSlot() >= event.getView().topInventory().getSize()) {
+            return;
+        }
+        event.setCancelled(true);
+        switch (event.getRawSlot()) {
+            case 22 -> teleport(player, "desert");
+            case 23 -> teleport(player, "feyforest");
+            case 31 -> teleport(player, "oaklands");
+            case 32 -> teleport(player, "frostland");
+        }
+    }
+
+    private void teleport(Player player, String key) {
+        Location loc = locations.get(key);
+        if (loc != null) {
+            player.closeInventory();
+            player.teleport(loc);
+        }
+    }
+}

--- a/Elytria Essentials/src/main/resources/config.yml
+++ b/Elytria Essentials/src/main/resources/config.yml
@@ -1,0 +1,22 @@
+npc-id: teleporter
+locations:
+  desert:
+    world: world
+    x: 0
+    y: 64
+    z: 0
+  feyforest:
+    world: world
+    x: 100
+    y: 64
+    z: 0
+  oaklands:
+    world: world
+    x: 200
+    y: 64
+    z: 0
+  frostland:
+    world: world
+    x: -100
+    y: 64
+    z: 0


### PR DESCRIPTION
## Summary
- add configurable NPC teleport GUI
- teleport players to Desert, Feyforest, Oaklands, and Frostland coordinates

## Testing
- `./gradlew build` *(fails: Could not resolve io.papermc.paper:paper-api:1.21.4-R0.1-SNAPSHOT)*

------
https://chatgpt.com/codex/tasks/task_e_68c0503af0d8832b9ea8bdb112d5059f