### PR TITLE
Fix inventory view call for legacy API

### DIFF
--- a/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/TeleportListener.java
+++ b/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/TeleportListener.java
@@ -123,7 +123,7 @@ public class TeleportListener implements Listener {
         if (!event.getView().title().equals(menuTitle)) {
             return;
         }
-        if (event.getClickedInventory() == null || event.getRawSlot() >= event.getView().topInventory().getSize()) {
+        if (event.getClickedInventory() == null || event.getRawSlot() >= event.getView().getTopInventory().getSize()) {
             return;
         }
         event.setCancelled(true);


### PR DESCRIPTION
## Summary
- Fix TeleportListener to use `getTopInventory()` for wider API compatibility

## Testing
- `./gradlew test` *(fails: Could not resolve io.papermc.paper:paper-api: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c056effae4832b953b3f90afa0aaba