### PR TITLE
Use Citizens NPC ID for teleport listener

### DIFF
--- a/Elytria Essentials/build.gradle
+++ b/Elytria Essentials/build.gradle
@@ -12,10 +12,15 @@ repositories {
         name = "papermc-repo"
         url = "https://repo.papermc.io/repository/maven-public/"
     }
+    maven {
+        name = "citizens-repo"
+        url = "https://repo.citizensnpcs.co/"
+    }
 }
 
 dependencies {
     compileOnly("io.papermc.paper:paper-api:1.21.4-R0.1-SNAPSHOT")
+    compileOnly("net.citizensnpcs:citizens-main:2.0.33-SNAPSHOT")
 }
 
 tasks {


### PR DESCRIPTION
## Summary
- Switch teleport listener to query Citizens API for NPC and match by its internal ID
- Add Citizens repository and dependency to build script

## Testing
- `./gradlew build` *(fails: Could not resolve io.papermc.paper:paper-api... 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c05bf04a94832baa2f9b4a4dfeaeb9