### PR TITLE
Block piston and hopper activity

### DIFF
--- a/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/Blockers/BlockersListener.java
+++ b/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/Blockers/BlockersListener.java
@@ -1,0 +1,42 @@
+package me.luisgamedev.elytriaEssentials.Blockers;
+
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockPistonExtendEvent;
+import org.bukkit.event.block.BlockPistonRetractEvent;
+import org.bukkit.event.inventory.InventoryMoveItemEvent;
+import org.bukkit.event.inventory.InventoryPickupItemEvent;
+import org.bukkit.inventory.InventoryType;
+
+/**
+ * Listener that prevents pistons from extending or retracting and
+ * disables all hopper item transfers and pickups.
+ */
+public class BlockersListener implements Listener {
+
+    @EventHandler
+    public void onPistonExtend(BlockPistonExtendEvent event) {
+        event.setCancelled(true);
+    }
+
+    @EventHandler
+    public void onPistonRetract(BlockPistonRetractEvent event) {
+        event.setCancelled(true);
+    }
+
+    @EventHandler
+    public void onInventoryMove(InventoryMoveItemEvent event) {
+        if (event.getSource().getType() == InventoryType.HOPPER ||
+            event.getDestination().getType() == InventoryType.HOPPER) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler
+    public void onHopperPickup(InventoryPickupItemEvent event) {
+        if (event.getInventory().getType() == InventoryType.HOPPER) {
+            event.setCancelled(true);
+        }
+    }
+}
+

--- a/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/ElytriaEssentials.java
+++ b/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/ElytriaEssentials.java
@@ -1,8 +1,10 @@
 package me.luisgamedev.elytriaEssentials;
 
-import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.PluginManager;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import me.luisgamedev.elytriaEssentials.Blockers.BlockersListener;
 
 public final class ElytriaEssentials extends JavaPlugin {
 
@@ -11,6 +13,7 @@ public final class ElytriaEssentials extends JavaPlugin {
         saveDefaultConfig();
         PluginManager pm = Bukkit.getPluginManager();
         pm.registerEvents(new TeleportListener(this), this);
+        pm.registerEvents(new BlockersListener(), this);
     }
 
     @Override


### PR DESCRIPTION
## Summary
- add BlockersListener to cancel piston movement and hopper item transfers
- register blocker listener in main plugin

## Testing
- `./gradlew test` *(fails: Could not resolve io.papermc.paper:paper-api:1.21.4-R0.1-SNAPSHOT, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c0890b4ffc832bacace3c09fc78c8a