### PR TITLE
Block redstone wires as power sources

### DIFF
--- a/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/Blockers/BlockersListener.java
+++ b/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/Blockers/BlockersListener.java
@@ -1,16 +1,19 @@
 package me.luisgamedev.elytriaEssentials.Blockers;
 
+import org.bukkit.Material;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockPistonExtendEvent;
 import org.bukkit.event.block.BlockPistonRetractEvent;
+import org.bukkit.event.block.BlockRedstoneEvent;
 import org.bukkit.event.inventory.InventoryMoveItemEvent;
 import org.bukkit.event.inventory.InventoryPickupItemEvent;
 import org.bukkit.inventory.InventoryType;
 
 /**
- * Listener that prevents pistons from extending or retracting and
- * disables all hopper item transfers and pickups.
+ * Listener that prevents pistons from extending or retracting,
+ * disables all hopper item transfers and pickups, and
+ * stops redstone wires from transmitting power.
  */
 public class BlockersListener implements Listener {
 
@@ -36,6 +39,13 @@ public class BlockersListener implements Listener {
     public void onHopperPickup(InventoryPickupItemEvent event) {
         if (event.getInventory().getType() == InventoryType.HOPPER) {
             event.setCancelled(true);
+        }
+    }
+
+    @EventHandler
+    public void onRedstoneChange(BlockRedstoneEvent event) {
+        if (event.getBlock().getType() == Material.REDSTONE_WIRE) {
+            event.setNewCurrent(0);
         }
     }
 }


### PR DESCRIPTION
## Summary
- stop redstone wire current propagation so only direct redstone power sources work

## Testing
- `./gradlew test` *(fails: Could not resolve io.papermc.paper:paper-api:1.21.4-R0.1-SNAPSHOT)*

------
https://chatgpt.com/codex/tasks/task_e_68c08c09a660832ba4a3b1b808ad4111