### PR TITLE
Block TNT ignition and dispensers

### DIFF
--- a/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/Blockers/BlockersListener.java
+++ b/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/Blockers/BlockersListener.java
@@ -3,6 +3,8 @@ package me.luisgamedev.elytriaEssentials.Blockers;
 import org.bukkit.Material;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockDispenseEvent;
+import org.bukkit.event.block.BlockIgniteEvent;
 import org.bukkit.event.block.BlockPistonExtendEvent;
 import org.bukkit.event.block.BlockPistonRetractEvent;
 import org.bukkit.event.block.BlockRedstoneEvent;
@@ -12,8 +14,9 @@ import org.bukkit.inventory.InventoryType;
 
 /**
  * Listener that prevents pistons from extending or retracting,
- * disables all hopper item transfers and pickups, and
- * stops redstone wires from transmitting power.
+ * disables all hopper item transfers and pickups,
+ * stops redstone wires from transmitting power, and
+ * blocks TNT ignition and dispenser usage.
  */
 public class BlockersListener implements Listener {
 
@@ -46,6 +49,20 @@ public class BlockersListener implements Listener {
     public void onRedstoneChange(BlockRedstoneEvent event) {
         if (event.getBlock().getType() == Material.REDSTONE_WIRE) {
             event.setNewCurrent(0);
+        }
+    }
+
+    @EventHandler
+    public void onTntIgnite(BlockIgniteEvent event) {
+        if (event.getBlock().getType() == Material.TNT) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler
+    public void onDispenser(BlockDispenseEvent event) {
+        if (event.getBlock().getType() == Material.DISPENSER) {
+            event.setCancelled(true);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Prevent TNT blocks from being ignited
- Cancel dispenser item dispensing
- Update blocker listener description

## Testing
- `bash gradlew build` *(fails: Could not resolve io.papermc.paper:paper-api:403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c08d5efa1c832b9ccf1f1ccafc04e7