### PR TITLE
Add database-backed clan system with LuckPerms integration

### DIFF
--- a/Elytria Essentials/build.gradle
+++ b/Elytria Essentials/build.gradle
@@ -16,11 +16,17 @@ repositories {
         name = "citizens-repo"
         url = "https://repo.citizensnpcs.co/"
     }
+    maven {
+        url = "https://repo.extendedclip.com/content/repositories/placeholderapi/"
+    }
 }
 
 dependencies {
     compileOnly("io.papermc.paper:paper-api:1.21.4-R0.1-SNAPSHOT")
     compileOnly files("libs/Citizens-2.0.33-b3399.jar")
+    compileOnly("net.luckperms:api:5.4")
+    compileOnly("me.clip:placeholderapi:2.11.5")
+    compileOnly("com.mysql:mysql-connector-j:8.3.0")
 }
 
 tasks {

--- a/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/ClanSystem/Clan.java
+++ b/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/ClanSystem/Clan.java
@@ -1,0 +1,54 @@
+package me.luisgamedev.elytriaEssentials.ClanSystem;
+
+import org.bukkit.Location;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Represents a clan of players.
+ */
+public class Clan {
+
+    private final String name;
+    private final String tag;
+    private UUID leader;
+    private final Set<UUID> members = new HashSet<>();
+    private Location home;
+
+    public Clan(String name, String tag, UUID leader) {
+        this.name = name;
+        this.tag = tag;
+        this.leader = leader;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getTag() {
+        return tag;
+    }
+
+    public UUID getLeader() {
+        return leader;
+    }
+
+    public void setLeader(UUID leader) {
+        this.leader = leader;
+    }
+
+    public Set<UUID> getMembers() {
+        return members;
+    }
+
+    public Location getHome() {
+        return home;
+    }
+
+    public void setHome(Location home) {
+        this.home = home;
+    }
+}
+

--- a/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/ClanSystem/ClanListener.java
+++ b/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/ClanSystem/ClanListener.java
@@ -1,0 +1,43 @@
+package me.luisgamedev.elytriaEssentials.ClanSystem;
+
+import net.luckperms.api.LuckPerms;
+import net.luckperms.api.LuckPermsProvider;
+import net.luckperms.api.model.user.User;
+import net.luckperms.api.node.Node;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+
+import java.time.Duration;
+
+/**
+ * Handles player join events for the clan system.
+ */
+public class ClanListener implements Listener {
+
+    private final ClanManager manager;
+    private final me.luisgamedev.elytriaEssentials.ElytriaEssentials plugin;
+
+    public ClanListener(me.luisgamedev.elytriaEssentials.ElytriaEssentials plugin, ClanManager manager) {
+        this.plugin = plugin;
+        this.manager = manager;
+    }
+
+    @EventHandler
+    public void onJoin(PlayerJoinEvent event) {
+        Player player = event.getPlayer();
+        LuckPerms lp = LuckPermsProvider.get();
+        User user = lp.getPlayerAdapter(Player.class).getUser(player);
+        long hours = plugin.getConfig().getLong("newbie-protection-hours");
+        Node node = Node.builder("faction.newbie").expiry(Duration.ofHours(hours)).build();
+        user.data().add(node);
+        lp.getUserManager().saveUser(user);
+
+        Clan clan = manager.getClan(player.getUniqueId());
+        if (clan != null) {
+            manager.giveClanPermission(player, clan.getName());
+        }
+    }
+}
+

--- a/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/ClanSystem/ClanManager.java
+++ b/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/ClanSystem/ClanManager.java
@@ -1,4 +1,275 @@
 package me.luisgamedev.elytriaEssentials.ClanSystem;
 
+import net.luckperms.api.LuckPerms;
+import net.luckperms.api.LuckPermsProvider;
+import net.luckperms.api.model.user.User;
+import net.luckperms.api.node.Node;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.*;
+
+/**
+ * Manages clan data and persistence.
+ */
 public class ClanManager {
+
+    private final me.luisgamedev.elytriaEssentials.ElytriaEssentials plugin;
+    private final Database database;
+
+    private final Map<String, Clan> clans = new HashMap<>();
+    private final Map<UUID, String> playerClan = new HashMap<>();
+    private final Map<UUID, String> invites = new HashMap<>();
+
+    public ClanManager(me.luisgamedev.elytriaEssentials.ElytriaEssentials plugin) {
+        this.plugin = plugin;
+        this.database = new Database(plugin);
+        initTables();
+        loadClans();
+    }
+
+    private void initTables() {
+        try (Connection conn = database.getConnection()) {
+            conn.createStatement().executeUpdate(
+                    "CREATE TABLE IF NOT EXISTS clans (name VARCHAR(25) PRIMARY KEY, tag VARCHAR(5), leader VARCHAR(36), home_world VARCHAR(64), home_x DOUBLE, home_y DOUBLE, home_z DOUBLE)"
+            );
+            conn.createStatement().executeUpdate(
+                    "CREATE TABLE IF NOT EXISTS clan_members (clan_name VARCHAR(25), uuid VARCHAR(36))"
+            );
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private void loadClans() {
+        try (Connection conn = database.getConnection()) {
+            PreparedStatement st = conn.prepareStatement("SELECT * FROM clans");
+            ResultSet rs = st.executeQuery();
+            while (rs.next()) {
+                String name = rs.getString("name");
+                String tag = rs.getString("tag");
+                UUID leader = UUID.fromString(rs.getString("leader"));
+                Clan clan = new Clan(name, tag, leader);
+                String world = rs.getString("home_world");
+                if (world != null) {
+                    Location loc = new Location(Bukkit.getWorld(world), rs.getDouble("home_x"), rs.getDouble("home_y"), rs.getDouble("home_z"));
+                    clan.setHome(loc);
+                }
+                clans.put(name.toLowerCase(), clan);
+            }
+            PreparedStatement st2 = conn.prepareStatement("SELECT * FROM clan_members");
+            ResultSet rs2 = st2.executeQuery();
+            while (rs2.next()) {
+                String clanName = rs2.getString("clan_name").toLowerCase();
+                UUID uuid = UUID.fromString(rs2.getString("uuid"));
+                Clan clan = clans.get(clanName);
+                if (clan != null) {
+                    clan.getMembers().add(uuid);
+                    playerClan.put(uuid, clanName);
+                }
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public Clan getClan(UUID uuid) {
+        String name = playerClan.get(uuid);
+        return name != null ? clans.get(name) : null;
+    }
+
+    public Clan getClanByName(String name) {
+        return clans.get(name.toLowerCase());
+    }
+
+    public boolean createClan(Player creator, String name, String tag) {
+        if (clans.containsKey(name.toLowerCase())) {
+            return false;
+        }
+        Clan clan = new Clan(name, tag, creator.getUniqueId());
+        clan.getMembers().add(creator.getUniqueId());
+        clans.put(name.toLowerCase(), clan);
+        playerClan.put(creator.getUniqueId(), name.toLowerCase());
+        try (Connection conn = database.getConnection()) {
+            PreparedStatement st = conn.prepareStatement("INSERT INTO clans(name, tag, leader) VALUES (?,?,?)");
+            st.setString(1, name);
+            st.setString(2, tag);
+            st.setString(3, creator.getUniqueId().toString());
+            st.executeUpdate();
+
+            PreparedStatement st2 = conn.prepareStatement("INSERT INTO clan_members(clan_name, uuid) VALUES (?,?)");
+            st2.setString(1, name);
+            st2.setString(2, creator.getUniqueId().toString());
+            st2.executeUpdate();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        giveClanPermission(creator, name);
+        return true;
+    }
+
+    public void disbandClan(Player player) {
+        Clan clan = getClan(player.getUniqueId());
+        if (clan == null || !clan.getLeader().equals(player.getUniqueId())) {
+            return;
+        }
+        clans.remove(clan.getName().toLowerCase());
+        for (UUID uuid : clan.getMembers()) {
+            playerClan.remove(uuid);
+            Player p = Bukkit.getPlayer(uuid);
+            if (p != null) {
+                removeClanPermission(p, clan.getName());
+            }
+        }
+        try (Connection conn = database.getConnection()) {
+            PreparedStatement delMembers = conn.prepareStatement("DELETE FROM clan_members WHERE clan_name=?");
+            delMembers.setString(1, clan.getName());
+            delMembers.executeUpdate();
+            PreparedStatement delClan = conn.prepareStatement("DELETE FROM clans WHERE name=?");
+            delClan.setString(1, clan.getName());
+            delClan.executeUpdate();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void invite(Player inviter, Player target) {
+        Clan clan = getClan(inviter.getUniqueId());
+        if (clan == null) return;
+        invites.put(target.getUniqueId(), clan.getName().toLowerCase());
+        target.sendMessage("You have been invited to clan " + clan.getName() + ". Use /clan accept to join.");
+    }
+
+    public void accept(Player player) {
+        String clanName = invites.remove(player.getUniqueId());
+        if (clanName == null) {
+            return;
+        }
+        Clan clan = clans.get(clanName);
+        if (clan == null) {
+            return;
+        }
+        int max = plugin.getConfig().getInt("max-members-per-clan");
+        if (clan.getMembers().size() >= max) {
+            return;
+        }
+        clan.getMembers().add(player.getUniqueId());
+        playerClan.put(player.getUniqueId(), clanName);
+        try (Connection conn = database.getConnection()) {
+            PreparedStatement st = conn.prepareStatement("INSERT INTO clan_members(clan_name, uuid) VALUES (?,?)");
+            st.setString(1, clan.getName());
+            st.setString(2, player.getUniqueId().toString());
+            st.executeUpdate();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        giveClanPermission(player, clan.getName());
+    }
+
+    public void kick(Player leader, Player target) {
+        Clan clan = getClan(leader.getUniqueId());
+        if (clan == null || !clan.getLeader().equals(leader.getUniqueId())) {
+            return;
+        }
+        clan.getMembers().remove(target.getUniqueId());
+        playerClan.remove(target.getUniqueId());
+        try (Connection conn = database.getConnection()) {
+            PreparedStatement st = conn.prepareStatement("DELETE FROM clan_members WHERE clan_name=? AND uuid=?");
+            st.setString(1, clan.getName());
+            st.setString(2, target.getUniqueId().toString());
+            st.executeUpdate();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        removeClanPermission(target, clan.getName());
+    }
+
+    public void leave(Player player) {
+        Clan clan = getClan(player.getUniqueId());
+        if (clan == null) return;
+        if (clan.getLeader().equals(player.getUniqueId())) {
+            return;
+        }
+        clan.getMembers().remove(player.getUniqueId());
+        playerClan.remove(player.getUniqueId());
+        try (Connection conn = database.getConnection()) {
+            PreparedStatement st = conn.prepareStatement("DELETE FROM clan_members WHERE clan_name=? AND uuid=?");
+            st.setString(1, clan.getName());
+            st.setString(2, player.getUniqueId().toString());
+            st.executeUpdate();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        removeClanPermission(player, clan.getName());
+    }
+
+    public void promote(Player leader, Player target) {
+        Clan clan = getClan(leader.getUniqueId());
+        if (clan == null || !clan.getLeader().equals(leader.getUniqueId())) {
+            return;
+        }
+        if (!clan.getMembers().contains(target.getUniqueId())) {
+            return;
+        }
+        clan.setLeader(target.getUniqueId());
+        try (Connection conn = database.getConnection()) {
+            PreparedStatement st = conn.prepareStatement("UPDATE clans SET leader=? WHERE name=?");
+            st.setString(1, target.getUniqueId().toString());
+            st.setString(2, clan.getName());
+            st.executeUpdate();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void setHome(Player player) {
+        Clan clan = getClan(player.getUniqueId());
+        if (clan == null || !clan.getLeader().equals(player.getUniqueId())) {
+            return;
+        }
+        Location loc = player.getLocation();
+        clan.setHome(loc);
+        try (Connection conn = database.getConnection()) {
+            PreparedStatement st = conn.prepareStatement("UPDATE clans SET home_world=?, home_x=?, home_y=?, home_z=? WHERE name=?");
+            st.setString(1, loc.getWorld().getName());
+            st.setDouble(2, loc.getX());
+            st.setDouble(3, loc.getY());
+            st.setDouble(4, loc.getZ());
+            st.setString(5, clan.getName());
+            st.executeUpdate();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void teleportHome(Player player) {
+        Clan clan = getClan(player.getUniqueId());
+        if (clan == null) return;
+        Location home = clan.getHome();
+        if (home != null) {
+            player.teleport(home);
+        }
+    }
+
+    public void giveClanPermission(Player player, String clanName) {
+        LuckPerms lp = LuckPermsProvider.get();
+        User user = lp.getPlayerAdapter(Player.class).getUser(player);
+        String perm = "faction." + clanName.toLowerCase();
+        user.data().add(Node.builder(perm).build());
+        lp.getUserManager().saveUser(user);
+    }
+
+    public void removeClanPermission(Player player, String clanName) {
+        LuckPerms lp = LuckPermsProvider.get();
+        User user = lp.getPlayerAdapter(Player.class).getUser(player);
+        String perm = "faction." + clanName.toLowerCase();
+        user.data().remove(Node.builder(perm).build());
+        lp.getUserManager().saveUser(user);
+    }
 }
+

--- a/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/ClanSystem/Commands/ClanCommand.java
+++ b/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/ClanSystem/Commands/ClanCommand.java
@@ -1,4 +1,103 @@
 package me.luisgamedev.elytriaEssentials.ClanSystem.Commands;
 
-public class ClanCommand {
+import me.luisgamedev.elytriaEssentials.ClanSystem.ClanManager;
+import org.bukkit.Bukkit;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.entity.Player;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class ClanCommand implements CommandExecutor, TabCompleter {
+
+    private final ClanManager manager;
+
+    public ClanCommand(ClanManager manager) {
+        this.manager = manager;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage("Only players may use this command.");
+            return true;
+        }
+        if (args.length == 0) {
+            player.sendMessage("/clan <create|invite|accept|disband|kick|leave|promote|sethome|home>");
+            return true;
+        }
+        String sub = args[0].toLowerCase();
+        switch (sub) {
+            case "create":
+                if (args.length < 3) {
+                    player.sendMessage("Usage: /clan create <name> <tag>");
+                    break;
+                }
+                manager.createClan(player, args[1], args[2]);
+                break;
+            case "invite":
+                if (args.length < 2) {
+                    player.sendMessage("Usage: /clan invite <player>");
+                    break;
+                }
+                Player targetInvite = Bukkit.getPlayer(args[1]);
+                if (targetInvite != null) {
+                    manager.invite(player, targetInvite);
+                }
+                break;
+            case "accept":
+                manager.accept(player);
+                break;
+            case "disband":
+                manager.disbandClan(player);
+                break;
+            case "kick":
+                if (args.length < 2) {
+                    player.sendMessage("Usage: /clan kick <player>");
+                    break;
+                }
+                Player targetKick = Bukkit.getPlayer(args[1]);
+                if (targetKick != null) {
+                    manager.kick(player, targetKick);
+                }
+                break;
+            case "leave":
+                manager.leave(player);
+                break;
+            case "promote":
+                if (args.length < 2) {
+                    player.sendMessage("Usage: /clan promote <player>");
+                    break;
+                }
+                Player targetPromote = Bukkit.getPlayer(args[1]);
+                if (targetPromote != null) {
+                    manager.promote(player, targetPromote);
+                }
+                break;
+            case "sethome":
+                manager.setHome(player);
+                break;
+            case "home":
+                manager.teleportHome(player);
+                break;
+            default:
+                player.sendMessage("Unknown subcommand.");
+        }
+        return true;
+    }
+
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+        if (args.length == 1) {
+            List<String> subs = new ArrayList<>();
+            Collections.addAll(subs, "create", "invite", "accept", "disband", "kick", "leave", "promote", "sethome", "home");
+            return subs;
+        }
+        return Collections.emptyList();
+    }
 }
+

--- a/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/ClanSystem/Database.java
+++ b/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/ClanSystem/Database.java
@@ -1,0 +1,32 @@
+package me.luisgamedev.elytriaEssentials.ClanSystem;
+
+import me.luisgamedev.elytriaEssentials.ElytriaEssentials;
+import org.bukkit.configuration.file.FileConfiguration;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+
+/**
+ * Simple helper for creating new database connections.
+ */
+public class Database {
+
+    private final ElytriaEssentials plugin;
+
+    public Database(ElytriaEssentials plugin) {
+        this.plugin = plugin;
+    }
+
+    public Connection getConnection() throws SQLException {
+        FileConfiguration cfg = plugin.getConfig();
+        String host = cfg.getString("host");
+        String user = cfg.getString("user");
+        String pass = cfg.getString("password");
+        String name = cfg.getString("name");
+        int port = cfg.getInt("port");
+        String url = "jdbc:mysql://" + host + ":" + port + "/" + name + "?useSSL=false";
+        return DriverManager.getConnection(url, user, pass);
+    }
+}
+

--- a/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/ClanSystem/Placeholders/RegisterPlaceholders.java
+++ b/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/ClanSystem/Placeholders/RegisterPlaceholders.java
@@ -1,4 +1,52 @@
 package me.luisgamedev.elytriaEssentials.ClanSystem.Placeholders;
 
-public class RegisterPlaceholders {
+import me.clip.placeholderapi.expansion.PlaceholderExpansion;
+import me.luisgamedev.elytriaEssentials.ClanSystem.Clan;
+import me.luisgamedev.elytriaEssentials.ClanSystem.ClanManager;
+import me.luisgamedev.elytriaEssentials.ElytriaEssentials;
+import org.bukkit.entity.Player;
+
+public class RegisterPlaceholders extends PlaceholderExpansion {
+
+    private final ElytriaEssentials plugin;
+    private final ClanManager manager;
+
+    public RegisterPlaceholders(ElytriaEssentials plugin, ClanManager manager) {
+        this.plugin = plugin;
+        this.manager = manager;
+    }
+
+    @Override
+    public String getIdentifier() {
+        return "elytria";
+    }
+
+    @Override
+    public String getAuthor() {
+        return plugin.getDescription().getAuthors().isEmpty() ? "" : plugin.getDescription().getAuthors().get(0);
+    }
+
+    @Override
+    public String getVersion() {
+        return plugin.getDescription().getVersion();
+    }
+
+    @Override
+    public String onPlaceholderRequest(Player player, String params) {
+        if (player == null) {
+            return "";
+        }
+        Clan clan = manager.getClan(player.getUniqueId());
+        if (params.equalsIgnoreCase("clantag")) {
+            return clan != null ? clan.getTag() : "";
+        }
+        if (params.equalsIgnoreCase("clanname")) {
+            return clan != null ? clan.getName() : "";
+        }
+        if (params.equalsIgnoreCase("clanmembersamount")) {
+            return clan != null ? String.valueOf(clan.getMembers().size()) : "0";
+        }
+        return null;
+    }
 }
+

--- a/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/ElytriaEssentials.java
+++ b/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/ElytriaEssentials.java
@@ -1,6 +1,10 @@
 package me.luisgamedev.elytriaEssentials;
 
 import me.luisgamedev.elytriaEssentials.OutpostTeleport.TeleportListener;
+import me.luisgamedev.elytriaEssentials.ClanSystem.ClanListener;
+import me.luisgamedev.elytriaEssentials.ClanSystem.ClanManager;
+import me.luisgamedev.elytriaEssentials.ClanSystem.Commands.ClanCommand;
+import me.luisgamedev.elytriaEssentials.ClanSystem.Placeholders.RegisterPlaceholders;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -9,12 +13,22 @@ import me.luisgamedev.elytriaEssentials.Blockers.BlockersListener;
 
 public final class ElytriaEssentials extends JavaPlugin {
 
+    private ClanManager clanManager;
+
     @Override
     public void onEnable() {
         saveDefaultConfig();
         PluginManager pm = Bukkit.getPluginManager();
         pm.registerEvents(new TeleportListener(this), this);
         pm.registerEvents(new BlockersListener(), this);
+        clanManager = new ClanManager(this);
+        pm.registerEvents(new ClanListener(this, clanManager), this);
+        ClanCommand clanCommand = new ClanCommand(clanManager);
+        getCommand("clan").setExecutor(clanCommand);
+        getCommand("clan").setTabCompleter(clanCommand);
+        if (Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI")) {
+            new RegisterPlaceholders(this, clanManager).register();
+        }
     }
 
     @Override

--- a/Elytria Essentials/src/main/resources/config.yml
+++ b/Elytria Essentials/src/main/resources/config.yml
@@ -34,4 +34,5 @@ name:
 max-clan-tag-length: 3
 max-clan-name-length: 25
 max-members-per-clan: 30
+newbie-protection-hours: 24
 

--- a/Elytria Essentials/src/main/resources/plugin.yml
+++ b/Elytria Essentials/src/main/resources/plugin.yml
@@ -3,3 +3,7 @@ version: '1.0'
 main: me.luisgamedev.elytriaEssentials.ElytriaEssentials
 api-version: '1.21'
 softdepend: [Citizens]
+commands:
+  clan:
+    description: Clan management command
+    usage: /clan


### PR DESCRIPTION
## Summary
- implement database-backed clan system with create/invite/accept/disband/kick/leave/promote/sethome/home commands
- assign newbie protection luckperms node on join and grant/revoke clan permissions
- register clan placeholders and command configuration

## Testing
- `./gradlew build` *(fails: Could not resolve dependencies, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c6a261ff30832b8fbeb7b81419eb75