### PR TITLE
Add clan members command and configurable language file

### DIFF
--- a/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/ClanSystem/ClanManager.java
+++ b/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/ClanSystem/ClanManager.java
@@ -142,7 +142,7 @@ public class ClanManager {
         Clan clan = getClan(inviter.getUniqueId());
         if (clan == null) return;
         invites.put(target.getUniqueId(), clan.getName().toLowerCase());
-        target.sendMessage("You have been invited to clan " + clan.getName() + ". Use /clan accept to join.");
+        target.sendMessage(plugin.getLanguageConfig().getString("clan.invited").replace("{name}", clan.getName()));
     }
 
     public void accept(Player player) {
@@ -254,6 +254,20 @@ public class ClanManager {
         if (home != null) {
             player.teleport(home);
         }
+    }
+
+    public void listMembers(Player player) {
+        Clan clan = getClan(player.getUniqueId());
+        if (clan == null) {
+            player.sendMessage(plugin.getLanguageConfig().getString("clan.no-clan"));
+            return;
+        }
+        List<String> names = new ArrayList<>();
+        for (UUID uuid : clan.getMembers()) {
+            names.add(Bukkit.getOfflinePlayer(uuid).getName());
+        }
+        String memberList = String.join(", ", names);
+        player.sendMessage(plugin.getLanguageConfig().getString("clan.members").replace("{clan}", clan.getName()).replace("{members}", memberList));
     }
 
     public void giveClanPermission(Player player, String clanName) {

--- a/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/ClanSystem/Commands/ClanCommand.java
+++ b/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/ClanSystem/Commands/ClanCommand.java
@@ -1,5 +1,6 @@
 package me.luisgamedev.elytriaEssentials.ClanSystem.Commands;
 
+import me.luisgamedev.elytriaEssentials.ElytriaEssentials;
 import me.luisgamedev.elytriaEssentials.ClanSystem.ClanManager;
 import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
@@ -15,33 +16,35 @@ import java.util.List;
 public class ClanCommand implements CommandExecutor, TabCompleter {
 
     private final ClanManager manager;
+    private final ElytriaEssentials plugin;
 
-    public ClanCommand(ClanManager manager) {
+    public ClanCommand(ElytriaEssentials plugin, ClanManager manager) {
+        this.plugin = plugin;
         this.manager = manager;
     }
 
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
         if (!(sender instanceof Player player)) {
-            sender.sendMessage("Only players may use this command.");
+            sender.sendMessage(plugin.getLanguageConfig().getString("clan.only-players"));
             return true;
         }
         if (args.length == 0) {
-            player.sendMessage("/clan <create|invite|accept|disband|kick|leave|promote|sethome|home>");
+            player.sendMessage(plugin.getLanguageConfig().getString("clan.help"));
             return true;
         }
         String sub = args[0].toLowerCase();
         switch (sub) {
             case "create":
                 if (args.length < 3) {
-                    player.sendMessage("Usage: /clan create <name> <tag>");
+                    player.sendMessage(plugin.getLanguageConfig().getString("clan.usage.create"));
                     break;
                 }
                 manager.createClan(player, args[1], args[2]);
                 break;
             case "invite":
                 if (args.length < 2) {
-                    player.sendMessage("Usage: /clan invite <player>");
+                    player.sendMessage(plugin.getLanguageConfig().getString("clan.usage.invite"));
                     break;
                 }
                 Player targetInvite = Bukkit.getPlayer(args[1]);
@@ -57,7 +60,7 @@ public class ClanCommand implements CommandExecutor, TabCompleter {
                 break;
             case "kick":
                 if (args.length < 2) {
-                    player.sendMessage("Usage: /clan kick <player>");
+                    player.sendMessage(plugin.getLanguageConfig().getString("clan.usage.kick"));
                     break;
                 }
                 Player targetKick = Bukkit.getPlayer(args[1]);
@@ -70,7 +73,7 @@ public class ClanCommand implements CommandExecutor, TabCompleter {
                 break;
             case "promote":
                 if (args.length < 2) {
-                    player.sendMessage("Usage: /clan promote <player>");
+                    player.sendMessage(plugin.getLanguageConfig().getString("clan.usage.promote"));
                     break;
                 }
                 Player targetPromote = Bukkit.getPlayer(args[1]);
@@ -84,8 +87,11 @@ public class ClanCommand implements CommandExecutor, TabCompleter {
             case "home":
                 manager.teleportHome(player);
                 break;
+            case "members":
+                manager.listMembers(player);
+                break;
             default:
-                player.sendMessage("Unknown subcommand.");
+                player.sendMessage(plugin.getLanguageConfig().getString("clan.unknown-subcommand"));
         }
         return true;
     }
@@ -94,7 +100,7 @@ public class ClanCommand implements CommandExecutor, TabCompleter {
     public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
         if (args.length == 1) {
             List<String> subs = new ArrayList<>();
-            Collections.addAll(subs, "create", "invite", "accept", "disband", "kick", "leave", "promote", "sethome", "home");
+            Collections.addAll(subs, "create", "invite", "accept", "disband", "kick", "leave", "promote", "sethome", "home", "members");
             return subs;
         }
         return Collections.emptyList();

--- a/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/ElytriaEssentials.java
+++ b/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/ElytriaEssentials.java
@@ -8,22 +8,32 @@ import me.luisgamedev.elytriaEssentials.ClanSystem.Placeholders.RegisterPlacehol
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+
+import java.io.File;
 
 import me.luisgamedev.elytriaEssentials.Blockers.BlockersListener;
 
 public final class ElytriaEssentials extends JavaPlugin {
 
     private ClanManager clanManager;
+    private FileConfiguration languageConfig;
 
     @Override
     public void onEnable() {
         saveDefaultConfig();
+        File langFile = new File(getDataFolder(), "language.yml");
+        if (!langFile.exists()) {
+            saveResource("language.yml", false);
+        }
+        languageConfig = YamlConfiguration.loadConfiguration(langFile);
         PluginManager pm = Bukkit.getPluginManager();
         pm.registerEvents(new TeleportListener(this), this);
         pm.registerEvents(new BlockersListener(), this);
         clanManager = new ClanManager(this);
         pm.registerEvents(new ClanListener(this, clanManager), this);
-        ClanCommand clanCommand = new ClanCommand(clanManager);
+        ClanCommand clanCommand = new ClanCommand(this, clanManager);
         getCommand("clan").setExecutor(clanCommand);
         getCommand("clan").setTabCompleter(clanCommand);
         if (Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI")) {
@@ -34,5 +44,9 @@ public final class ElytriaEssentials extends JavaPlugin {
     @Override
     public void onDisable() {
         // Plugin shutdown logic
+    }
+
+    public FileConfiguration getLanguageConfig() {
+        return languageConfig;
     }
 }

--- a/Elytria Essentials/src/main/resources/language.yml
+++ b/Elytria Essentials/src/main/resources/language.yml
@@ -1,0 +1,12 @@
+clan:
+  only-players: "Only players may use this command."
+  help: "/clan <create|invite|accept|disband|kick|leave|promote|sethome|home|members>"
+  usage:
+    create: "Usage: /clan create <name> <tag>"
+    invite: "Usage: /clan invite <player>"
+    kick: "Usage: /clan kick <player>"
+    promote: "Usage: /clan promote <player>"
+  unknown-subcommand: "Unknown subcommand."
+  invited: "You have been invited to clan {name}. Use /clan accept to join."
+  no-clan: "You are not in a clan."
+  members: "Members of {clan}: {members}"


### PR DESCRIPTION
## Summary
- add `members` subcommand to `/clan` for listing clan members
- externalize clan system messages to new `language.yml`
- load language configuration on startup

## Testing
- `bash ./gradlew build` *(fails: Could not resolve dependency io.papermc.paper:paper-api:1.21.4-R0.1-SNAPSHOT)*

------
https://chatgpt.com/codex/tasks/task_e_68c6a59d84ac832bae12c33a9a60e41c