### PR TITLE
Restrict clan names and tags to alphanumeric characters

### DIFF
--- a/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/ClanSystem/ClanManager.java
+++ b/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/ClanSystem/ClanManager.java
@@ -88,6 +88,14 @@ public class ClanManager {
     }
 
     public boolean createClan(Player creator, String name, String tag) {
+        if (!name.matches("[A-Za-z0-9]+")) {
+            creator.sendMessage(plugin.getLanguageConfig().getString("clan.invalid-name"));
+            return false;
+        }
+        if (!tag.matches("[A-Za-z0-9]+")) {
+            creator.sendMessage(plugin.getLanguageConfig().getString("clan.invalid-tag"));
+            return false;
+        }
         if (clans.containsKey(name.toLowerCase())) {
             return false;
         }

--- a/Elytria Essentials/src/main/resources/language.yml
+++ b/Elytria Essentials/src/main/resources/language.yml
@@ -7,6 +7,8 @@ clan:
     kick: "Usage: /clan kick <player>"
     promote: "Usage: /clan promote <player>"
   unknown-subcommand: "Unknown subcommand."
+  invalid-name: "Clan name can only contain letters and numbers."
+  invalid-tag: "Clan tag can only contain letters and numbers."
   invited: "You have been invited to clan {name}. Use /clan accept to join."
   no-clan: "You are not in a clan."
   members: "Members of {clan}: {members}"


### PR DESCRIPTION
## Summary
- enforce alphanumeric-only clan names and tags when creating a clan
- add localized messages for invalid clan names or tags

## Testing
- `./gradlew build` *(fails: 403 Forbidden fetching dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68c6a99cff0c832bafbebd1764fb64fb