### PR TITLE
Improve clan membership handling and info command

### DIFF
--- a/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/ClanSystem/Clan.java
+++ b/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/ClanSystem/Clan.java
@@ -16,11 +16,17 @@ public class Clan {
     private UUID leader;
     private final Set<UUID> members = new HashSet<>();
     private Location home;
+    private final long createdAt;
 
     public Clan(String name, String tag, UUID leader) {
+        this(name, tag, leader, System.currentTimeMillis());
+    }
+
+    public Clan(String name, String tag, UUID leader, long createdAt) {
         this.name = name;
         this.tag = tag;
         this.leader = leader;
+        this.createdAt = createdAt;
     }
 
     public String getName() {
@@ -49,6 +55,10 @@ public class Clan {
 
     public void setHome(Location home) {
         this.home = home;
+    }
+
+    public long getCreatedAt() {
+        return createdAt;
     }
 }
 

--- a/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/ClanSystem/ClanListener.java
+++ b/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/ClanSystem/ClanListener.java
@@ -27,12 +27,14 @@ public class ClanListener implements Listener {
     @EventHandler
     public void onJoin(PlayerJoinEvent event) {
         Player player = event.getPlayer();
-        LuckPerms lp = LuckPermsProvider.get();
-        User user = lp.getPlayerAdapter(Player.class).getUser(player);
-        long hours = plugin.getConfig().getLong("newbie-protection-hours");
-        Node node = Node.builder("faction.newbie").expiry(Duration.ofHours(hours)).build();
-        user.data().add(node);
-        lp.getUserManager().saveUser(user);
+        if (!player.hasPlayedBefore()) {
+            LuckPerms lp = LuckPermsProvider.get();
+            User user = lp.getPlayerAdapter(Player.class).getUser(player);
+            long hours = plugin.getConfig().getLong("newbie-protection-hours");
+            Node node = Node.builder("faction.newbie").expiry(Duration.ofHours(hours)).build();
+            user.data().add(node);
+            lp.getUserManager().saveUser(user);
+        }
 
         Clan clan = manager.getClan(player.getUniqueId());
         if (clan != null) {

--- a/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/ClanSystem/Commands/ClanCommand.java
+++ b/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/ClanSystem/Commands/ClanCommand.java
@@ -87,8 +87,9 @@ public class ClanCommand implements CommandExecutor, TabCompleter {
             case "home":
                 manager.teleportHome(player);
                 break;
-            case "members":
-                manager.listMembers(player);
+            case "info":
+                String clanName = args.length >= 2 ? args[1] : null;
+                manager.showClanInfo(player, clanName);
                 break;
             default:
                 player.sendMessage(plugin.getMessage("clan.unknown-subcommand"));
@@ -100,7 +101,7 @@ public class ClanCommand implements CommandExecutor, TabCompleter {
     public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
         if (args.length == 1) {
             List<String> subs = new ArrayList<>();
-            Collections.addAll(subs, "create", "invite", "accept", "disband", "kick", "leave", "promote", "sethome", "home", "members");
+            Collections.addAll(subs, "create", "invite", "accept", "disband", "kick", "leave", "promote", "sethome", "home", "info");
             return subs;
         }
         return Collections.emptyList();

--- a/Elytria Essentials/src/main/resources/language.yml
+++ b/Elytria Essentials/src/main/resources/language.yml
@@ -1,7 +1,7 @@
 prefix: "&7[&bElytria&7] "
 clan:
   only-players: "&cOnly players may use this command."
-  help: "&e/clan <create|invite|accept|disband|kick|leave|promote|sethome|home|members>"
+  help: "&e/clan <create|invite|accept|disband|kick|leave|promote|sethome|home|info>"
   usage:
     create: "&cUsage: /clan create <name> <tag>"
     invite: "&cUsage: /clan invite <player>"
@@ -17,6 +17,8 @@ clan:
   not-leader: "&cYou must be the clan leader to do this."
   no-invite: "&cYou have no pending clan invites."
   full: "&cClan is full."
+  already-in-clan: "&cYou are already in a clan."
+  no-exist: "&cClan {clan} does not exist."
   create-success: "&aCreated clan {name} with tag {tag}."
   disband-success: "&cClan {name} disbanded."
   accept-success: "&aYou joined clan {clan}."
@@ -29,4 +31,8 @@ clan:
   sethome-success: "&aClan home set."
   home-success: "&aTeleported to clan home."
   home-not-set: "&cClan home not set."
-  members: "&eMembers of {clan}: {members}"
+  info:
+    header: "&eClan info for {clan}:"
+    leader: "&eLeader: {leader}"
+    created: "&eCreated: {date}"
+    members: "&eMembers: {members}"


### PR DESCRIPTION
## Summary
- Only allow clan creation or joining when not already in a clan
- Add clan info command showing leader, creation date, and member status
- Grant newbie protection only on first join

## Testing
- `bash ./gradlew build` *(fails: Could not resolve dependencies, status code 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c6b9180d3c832ba117ce18c81a757e