### PR TITLE
Track clan sethome cooldown per clan

### DIFF
--- a/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/ClanSystem/ClanManager.java
+++ b/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/ClanSystem/ClanManager.java
@@ -33,7 +33,7 @@ public class ClanManager {
     private final Map<UUID, String> playerClan = new HashMap<>();
     private final Map<UUID, String> invites = new HashMap<>();
     private final Map<UUID, Long> homeCooldowns = new HashMap<>();
-    private final Map<UUID, Long> setHomeCooldowns = new HashMap<>();
+    private final Map<String, Long> setHomeCooldowns = new HashMap<>();
 
     public ClanManager(me.luisgamedev.elytriaEssentials.ElytriaEssentials plugin) {
         this.plugin = plugin;
@@ -311,13 +311,13 @@ public class ClanManager {
         }
         long now = System.currentTimeMillis();
         long cooldown = plugin.getConfig().getLong("clan-sethome-cooldown") * 1000L;
-        Long last = setHomeCooldowns.get(player.getUniqueId());
+        Long last = setHomeCooldowns.get(clan.getName());
         if (last != null && now - last < cooldown) {
             long remaining = (cooldown - (now - last)) / 1000L;
             player.sendMessage(plugin.getMessage("clan.sethome-cooldown").replace("{seconds}", String.valueOf(remaining)));
             return;
         }
-        setHomeCooldowns.put(player.getUniqueId(), now);
+        setHomeCooldowns.put(clan.getName(), now);
         Location loc = player.getLocation();
         clan.setHome(loc);
         try (Connection conn = database.getConnection()) {


### PR DESCRIPTION
## Summary
- Scope clan sethome cooldown to the entire clan rather than individual players

## Testing
- `./gradlew build` *(fails: Could not resolve io.papermc.paper:paper-api:403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c6e44f70e4832b9e0d16fe3aec4075