### PR TITLE
Remove experience orbs from spawning

### DIFF
--- a/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/Blockers/BlockersListener.java
+++ b/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/Blockers/BlockersListener.java
@@ -170,10 +170,15 @@ public class BlockersListener implements Listener {
     }
 
     @EventHandler
-    public void onTntSpawn(EntitySpawnEvent event) {
-        if (event.getEntity() instanceof TNTPrimed) {
+    public void onEntitySpawn(EntitySpawnEvent event) {
+        if (event.getEntity() instanceof TNTPrimed || event.getEntityType() == EntityType.EXPERIENCE_ORB) {
             event.setCancelled(true);
         }
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void onEntityDeath(EntityDeathEvent event) {
+        event.setDroppedExp(0);
     }
 
     @EventHandler


### PR DESCRIPTION
## Summary
- cancel experience orb spawns in the blockers listener
- prevent experience from dropping when entities die

## Testing
- `bash gradlew build` *(fails: remote repositories return HTTP 403, preventing dependency downloads)*

------
https://chatgpt.com/codex/tasks/task_e_68c90c37c250832b859cfc0f97db39ac