### PR TITLE
Display clan home cooldown in human-readable time and add member tab completion

### DIFF
--- a/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/ClanSystem/ClanManager.java
+++ b/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/ClanSystem/ClanManager.java
@@ -330,7 +330,7 @@ public class ClanManager {
         Long last = setHomeCooldowns.get(clan.getName());
         if (last != null && now - last < cooldown) {
             long remaining = (cooldown - (now - last)) / 1000L;
-            player.sendMessage(plugin.getMessage("clan.sethome-cooldown").replace("{seconds}", String.valueOf(remaining)));
+            player.sendMessage(plugin.getMessage("clan.sethome-cooldown").replace("{time}", formatTime(remaining)));
             return;
         }
         setHomeCooldowns.put(clan.getName(), now);
@@ -361,7 +361,7 @@ public class ClanManager {
         Long last = homeCooldowns.get(player.getUniqueId());
         if (last != null && now - last < cooldown) {
             long remaining = (cooldown - (now - last)) / 1000L;
-            player.sendMessage(plugin.getMessage("clan.home-cooldown").replace("{seconds}", String.valueOf(remaining)));
+            player.sendMessage(plugin.getMessage("clan.home-cooldown").replace("{time}", formatTime(remaining)));
             return;
         }
         homeCooldowns.put(player.getUniqueId(), now);
@@ -420,6 +420,25 @@ public class ClanManager {
         String perm = "faction." + clanName.toLowerCase();
         user.data().remove(Node.builder(perm).build());
         lp.getUserManager().saveUser(user);
+    }
+
+    private String formatTime(long seconds) {
+        long hours = seconds / 3600;
+        long minutes = (seconds % 3600) / 60;
+        StringBuilder sb = new StringBuilder();
+        if (hours > 0) {
+            sb.append(hours).append(" hour");
+            if (hours != 1) sb.append('s');
+        }
+        if (minutes > 0) {
+            if (sb.length() > 0) sb.append(' ');
+            sb.append(minutes).append(" minute");
+            if (minutes != 1) sb.append('s');
+        }
+        if (sb.length() == 0) {
+            sb.append("<1 minute");
+        }
+        return sb.toString();
     }
 }
 

--- a/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/ClanSystem/Commands/ClanCommand.java
+++ b/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/ClanSystem/Commands/ClanCommand.java
@@ -12,6 +12,9 @@ import org.bukkit.entity.Player;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
+
+import me.luisgamedev.elytriaEssentials.ClanSystem.Clan;
 
 public class ClanCommand implements CommandExecutor, TabCompleter {
 
@@ -103,6 +106,22 @@ public class ClanCommand implements CommandExecutor, TabCompleter {
             List<String> subs = new ArrayList<>();
             Collections.addAll(subs, "create", "invite", "accept", "disband", "kick", "leave", "promote", "sethome", "home", "info");
             return subs;
+        }
+        if (args.length == 2) {
+            String sub = args[0].toLowerCase();
+            if ((sub.equals("kick") || sub.equals("promote")) && sender instanceof Player player) {
+                Clan clan = manager.getClan(player.getUniqueId());
+                if (clan != null) {
+                    List<String> names = new ArrayList<>();
+                    for (UUID uuid : clan.getMembers()) {
+                        String name = Bukkit.getOfflinePlayer(uuid).getName();
+                        if (name != null) {
+                            names.add(name);
+                        }
+                    }
+                    return names;
+                }
+            }
         }
         return Collections.emptyList();
     }

--- a/Elytria Essentials/src/main/resources/language.yml
+++ b/Elytria Essentials/src/main/resources/language.yml
@@ -30,10 +30,10 @@ clan:
   promote-success: "&aPromoted {player} to leader."
   promote-target: "&eYou are now the leader of clan {clan}."
   sethome-success: "&aClan home set."
-  sethome-cooldown: "&cYou must wait {seconds}s before setting the clan home again."
+  sethome-cooldown: "&cYou must wait {time} before setting the clan home again."
   home-success: "&aTeleported to clan home."
   home-not-set: "&cClan home not set."
-  home-cooldown: "&cYou must wait {seconds}s before using clan home again."
+  home-cooldown: "&cYou must wait {time} before using clan home again."
   info:
     header: "&eClan info for {clan}:"
     leader: "&eLeader: {leader}"


### PR DESCRIPTION
## Summary
- Format clan home and sethome cooldown messages using hours and minutes
- Suggest clan members for `/clan kick` and `/clan promote` via tab completion
- Update language strings to use a `{time}` placeholder

## Testing
- `bash ./gradlew build` *(fails: Could not resolve dependencies from remote repositories)*

------
https://chatgpt.com/codex/tasks/task_e_68c71bc32784832b9746604b38c052ea