### PR TITLE
Add cooldown for clan friendly fire warning

### DIFF
--- a/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/ClanSystem/ClanListener.java
+++ b/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/ClanSystem/ClanListener.java
@@ -12,6 +12,9 @@ import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.entity.Projectile;
 
 import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
 
 /**
  * Handles player join events for the clan system.
@@ -20,6 +23,9 @@ public class ClanListener implements Listener {
 
     private final ClanManager manager;
     private final me.luisgamedev.elytriaEssentials.ElytriaEssentials plugin;
+    private final Map<UUID, Long> lastFriendlyFireMessage = new HashMap<>();
+
+    private static final long FRIENDLY_FIRE_MESSAGE_COOLDOWN = 5000L;
 
     public ClanListener(me.luisgamedev.elytriaEssentials.ElytriaEssentials plugin, ClanManager manager) {
         this.plugin = plugin;
@@ -61,6 +67,13 @@ public class ClanListener implements Listener {
         Clan attackerClan = manager.getClan(attacker.getUniqueId());
         if (attackerClan != null && attackerClan == manager.getClan(victim.getUniqueId())) {
             event.setCancelled(true);
+            UUID attackerId = attacker.getUniqueId();
+            long now = System.currentTimeMillis();
+            Long lastSent = lastFriendlyFireMessage.get(attackerId);
+            if (lastSent == null || now - lastSent >= FRIENDLY_FIRE_MESSAGE_COOLDOWN) {
+                lastFriendlyFireMessage.put(attackerId, now);
+                attacker.sendMessage(plugin.getMessage("clan.cannot-attack-member"));
+            }
         }
     }
 }

--- a/Elytria Essentials/src/main/resources/language.yml
+++ b/Elytria Essentials/src/main/resources/language.yml
@@ -37,6 +37,7 @@ clan:
   home-success: "&aTeleported to clan home."
   home-not-set: "&cClan home not set."
   home-cooldown: "&cYou must wait {time} before using clan home again."
+  cannot-attack-member: "&cYou can't attack your clan members."
   info:
     header: "&eClan info for {clan}:"
     leader: "&eLeader: {leader}"


### PR DESCRIPTION
## Summary
- add a per-player cooldown before sending the clan friendly-fire warning again
- expose the warning text through the language file for easier customization

## Testing
- bash ./gradlew build *(fails: cannot download dependencies due to HTTP 403 responses)*

------
https://chatgpt.com/codex/tasks/task_e_68cad2b141dc832b9fd65f12dc1387c6