### PR TITLE
Add tab completion for clan invite

### DIFF
--- a/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/ClanSystem/Commands/ClanCommand.java
+++ b/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/ClanSystem/Commands/ClanCommand.java
@@ -138,6 +138,25 @@ public class ClanCommand implements CommandExecutor, TabCompleter {
             if (sub.equals("disband")) {
                 return Collections.singletonList("confirm");
             }
+            if (sub.equals("invite") && sender instanceof Player player) {
+                Clan clan = manager.getClan(player.getUniqueId());
+                if (clan != null) {
+                    List<String> names = new ArrayList<>();
+                    for (Player online : Bukkit.getOnlinePlayers()) {
+                        if (online.getUniqueId().equals(player.getUniqueId())) {
+                            continue;
+                        }
+                        if (clan.getMembers().contains(online.getUniqueId())) {
+                            continue;
+                        }
+                        if (manager.getClan(online.getUniqueId()) != null) {
+                            continue;
+                        }
+                        names.add(online.getName());
+                    }
+                    return names;
+                }
+            }
             if (sub.equals("promote") && sender instanceof Player player) {
                 List<String> names = new ArrayList<>();
                 names.add("confirm");


### PR DESCRIPTION
## Summary
- add tab completion for `/clan invite` that suggests online players the executor can invite
- filter suggestions to exclude the executor, current clan members, and players already in a clan

## Testing
- ./gradlew build *(fails: dependency downloads blocked with HTTP 403 from PaperMC and PlaceholderAPI repositories)*

------
https://chatgpt.com/codex/tasks/task_e_68cb0254e254832ba026826fd87090cb