### PR TITLE
Replace custom repair anvil with chest interface

### DIFF
--- a/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/CustomRepair/CustomRepairManager.java
+++ b/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/CustomRepair/CustomRepairManager.java
@@ -6,6 +6,7 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.milkbowl.vault.economy.Economy;
 import net.milkbowl.vault.economy.EconomyResponse;
+import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.configuration.ConfigurationSection;
@@ -16,10 +17,10 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.event.inventory.InventoryDragEvent;
-import org.bukkit.event.inventory.PrepareAnvilEvent;
-import org.bukkit.inventory.AnvilInventory;
+import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryView;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.PlayerInventory;
 import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.persistence.PersistentDataContainer;
@@ -34,6 +35,11 @@ import java.util.Set;
 import java.util.UUID;
 
 public class CustomRepairManager implements Listener {
+    private static final int INVENTORY_SIZE = 27;
+    private static final int INPUT_SLOT = 10;
+    private static final int INFO_SLOT = 13;
+    private static final int RESULT_SLOT = 16;
+
     private final ElytriaEssentials plugin;
     private final Economy economy;
     private final Set<Integer> repairNpcIds;
@@ -42,6 +48,7 @@ public class CustomRepairManager implements Listener {
     private final NamespacedKey repairCountKey;
     private final Map<UUID, RepairSession> sessions = new HashMap<>();
     private final Component menuTitle = Component.text("Custom Repair", NamedTextColor.GOLD);
+    private final ItemStack fillerItem;
     private final boolean active;
 
     public CustomRepairManager(ElytriaEssentials plugin, Economy economy) {
@@ -62,6 +69,7 @@ public class CustomRepairManager implements Listener {
             active = enabled && !repairNpcIds.isEmpty() && economy != null;
         }
         this.repairCountKey = new NamespacedKey(plugin, "repairs_done");
+        this.fillerItem = createFillerItem();
 
         if (!active) {
             if (economy == null) {
@@ -91,61 +99,229 @@ public class CustomRepairManager implements Listener {
     }
 
     private void openRepairMenu(Player player) {
-        InventoryView view = player.openAnvil(player.getLocation(), true);
-        if (view == null) {
-            plugin.getLogger().warning("Failed to open custom repair menu for " + player.getName());
-            return;
+        UUID uuid = player.getUniqueId();
+        RepairSession previous = sessions.remove(uuid);
+        if (previous != null) {
+            returnItems(player, previous);
         }
 
-        view.setTitle("Repair");
-        if (!(view.getTopInventory() instanceof AnvilInventory inventory)) {
-            plugin.getLogger().warning("Custom repair menu opened without an anvil inventory for " + player.getName());
-            return;
-        }
-        inventory.setItem(1, createInfoItem(Component.text("Insert an item to repair", NamedTextColor.YELLOW), List.of()));
-        sessions.put(player.getUniqueId(), new RepairSession());
+        Inventory inventory = Bukkit.createInventory(player, INVENTORY_SIZE, menuTitle);
+        fillMenuLayout(inventory);
+        RepairSession session = new RepairSession(inventory);
+        sessions.put(uuid, session);
+        player.openInventory(inventory);
     }
 
     @EventHandler
-    public void onPrepareAnvil(PrepareAnvilEvent event) {
+    public void onInventoryClick(InventoryClickEvent event) {
+        if (!(event.getWhoClicked() instanceof Player player)) {
+            return;
+        }
+
+        RepairSession session = sessions.get(player.getUniqueId());
+        if (session == null) {
+            return;
+        }
+
         InventoryView view = event.getView();
-        if (!menuTitle.equals(view.title())) {
+        Inventory topInventory = view.getTopInventory();
+        if (topInventory != session.getInventory()) {
             return;
         }
 
-        if (!(view.getPlayer() instanceof Player player)) {
+        int rawSlot = event.getRawSlot();
+        if (rawSlot < topInventory.getSize()) {
+            if (rawSlot == RESULT_SLOT) {
+                event.setCancelled(true);
+                handleResultClick(player, session, event.isShiftClick());
+                return;
+            }
+
+            if (rawSlot == INPUT_SLOT) {
+                // allow interaction but update afterwards
+                scheduleRefresh(player, session);
+                return;
+            }
+
+            event.setCancelled(true);
             return;
         }
 
-        if (!(event.getInventory() instanceof AnvilInventory inventory)) {
+        if (event.isShiftClick()) {
+            event.setCancelled(true);
+            attemptTransferToInput(player, session, event);
             return;
         }
 
-        RepairSession session = sessions.computeIfAbsent(player.getUniqueId(), uuid -> new RepairSession());
-        session.reset();
+        scheduleRefresh(player, session);
+    }
 
-        inventory.setRepairCost(0);
-        ItemStack input = inventory.getItem(0);
+    @EventHandler
+    public void onInventoryDrag(InventoryDragEvent event) {
+        if (!(event.getWhoClicked() instanceof Player player)) {
+            return;
+        }
+
+        RepairSession session = sessions.get(player.getUniqueId());
+        if (session == null) {
+            return;
+        }
+
+        Inventory inventory = session.getInventory();
+        if (event.getInventory() != inventory) {
+            return;
+        }
+
+        for (int slot : event.getRawSlots()) {
+            if (slot < inventory.getSize() && slot != INPUT_SLOT) {
+                event.setCancelled(true);
+                return;
+            }
+        }
+
+        if (event.getRawSlots().contains(INPUT_SLOT)) {
+            scheduleRefresh(player, session);
+        }
+    }
+
+    @EventHandler
+    public void onInventoryClose(InventoryCloseEvent event) {
+        if (!(event.getPlayer() instanceof Player player)) {
+            return;
+        }
+
+        UUID uuid = player.getUniqueId();
+        RepairSession session = sessions.get(uuid);
+        if (session == null) {
+            return;
+        }
+
+        Inventory inventory = session.getInventory();
+        if (event.getInventory() != inventory) {
+            return;
+        }
+
+        returnItems(player, session);
+        sessions.remove(uuid);
+    }
+
+    private void handleResultClick(Player player, RepairSession session, boolean shiftClick) {
+        if (!session.isReady()) {
+            if (!session.isItemPresent()) {
+                player.sendMessage(Component.text("Place an item in the left slot to repair it.", NamedTextColor.YELLOW));
+            } else if (!session.isRepairable()) {
+                player.sendMessage(Component.text("That item cannot be repaired.", NamedTextColor.RED));
+            } else if (session.isAlreadyRepaired()) {
+                player.sendMessage(Component.text("That item is already fully repaired.", NamedTextColor.GREEN));
+            } else if (!session.isAffordable()) {
+                player.sendMessage(Component.text("You do not have enough money to repair this item.", NamedTextColor.RED));
+            }
+            return;
+        }
+
+        double cost = session.getCost();
+        if (!economy.has(player, cost)) {
+            player.sendMessage(Component.text("You no longer have enough money to repair this item.", NamedTextColor.RED));
+            session.setAffordable(false);
+            refreshSession(player, session);
+            return;
+        }
+
+        EconomyResponse response = economy.withdrawPlayer(player, cost);
+        if (!response.transactionSuccess()) {
+            player.sendMessage(Component.text("The transaction failed: " + response.errorMessage, NamedTextColor.RED));
+            return;
+        }
+
+        ItemStack result = session.getResultItem().clone();
+        Inventory inventory = session.getInventory();
+        inventory.setItem(INPUT_SLOT, null);
+        inventory.setItem(RESULT_SLOT, null);
+        inventory.setItem(INFO_SLOT, createInfoItem(Component.text("Insert an item to repair", NamedTextColor.YELLOW), List.of(), Material.PAPER));
+        session.clearState();
+
+        if (shiftClick) {
+            Map<Integer, ItemStack> remaining = player.getInventory().addItem(result);
+            remaining.values().forEach(item -> player.getWorld().dropItemNaturally(player.getLocation(), item));
+        } else {
+            ItemStack cursor = player.getItemOnCursor();
+            if (cursor == null || cursor.getType().isAir()) {
+                player.setItemOnCursor(result);
+            } else {
+                Map<Integer, ItemStack> remaining = player.getInventory().addItem(result);
+                remaining.values().forEach(item -> player.getWorld().dropItemNaturally(player.getLocation(), item));
+            }
+        }
+
+        player.sendMessage(Component.text("Paid " + formatCurrency(cost) + " to repair your item.", NamedTextColor.GOLD));
+    }
+
+    private void attemptTransferToInput(Player player, RepairSession session, InventoryClickEvent event) {
+        ItemStack clicked = event.getCurrentItem();
+        if (clicked == null || clicked.getType().isAir()) {
+            return;
+        }
+
+        Inventory inventory = session.getInventory();
+        ItemStack input = inventory.getItem(INPUT_SLOT);
+        if (input != null && !input.getType().isAir()) {
+            return;
+        }
+
+        ItemStack toMove = clicked.clone();
+        toMove.setAmount(1);
+        inventory.setItem(INPUT_SLOT, toMove);
+
+        PlayerInventory playerInventory = player.getInventory();
+        int slot = event.getSlot();
+        if (clicked.getAmount() <= 1) {
+            playerInventory.setItem(slot, null);
+        } else {
+            clicked.setAmount(clicked.getAmount() - 1);
+            playerInventory.setItem(slot, clicked);
+        }
+
+        scheduleRefresh(player, session);
+    }
+
+    private void scheduleRefresh(Player player, RepairSession session) {
+        Bukkit.getScheduler().runTask(plugin, () -> {
+            if (!player.isOnline()) {
+                return;
+            }
+            InventoryView view = player.getOpenInventory();
+            if (view == null) {
+                return;
+            }
+            if (view.getTopInventory() != session.getInventory()) {
+                return;
+            }
+            refreshSession(player, session);
+        });
+    }
+
+    private void refreshSession(Player player, RepairSession session) {
+        Inventory inventory = session.getInventory();
+        ItemStack input = inventory.getItem(INPUT_SLOT);
+        session.clearState();
+        inventory.setItem(RESULT_SLOT, null);
 
         if (input == null || input.getType().isAir()) {
-            inventory.setItem(1, createInfoItem(Component.text("Insert an item to repair", NamedTextColor.YELLOW), List.of()));
-            event.setResult(null);
+            inventory.setItem(INFO_SLOT, createInfoItem(Component.text("Insert an item to repair", NamedTextColor.YELLOW), List.of(), Material.PAPER));
             return;
         }
 
         session.setItemPresent(true);
         if (!(input.getItemMeta() instanceof Damageable damageable) || input.getType().getMaxDurability() <= 0) {
             session.setRepairable(false);
-            inventory.setItem(1, createInfoItem(Component.text("This item cannot be repaired", NamedTextColor.RED), List.of()));
-            event.setResult(null);
+            inventory.setItem(INFO_SLOT, createInfoItem(Component.text("This item cannot be repaired", NamedTextColor.RED), List.of(), Material.BARRIER));
             return;
         }
 
         int damage = damageable.getDamage();
         if (damage <= 0) {
             session.setAlreadyRepaired(true);
-            inventory.setItem(1, createInfoItem(Component.text("Item is already fully repaired", NamedTextColor.GREEN), List.of()));
-            event.setResult(null);
+            inventory.setItem(INFO_SLOT, createInfoItem(Component.text("Item is already fully repaired", NamedTextColor.GREEN), List.of(), Material.LIME_DYE));
             return;
         }
 
@@ -164,13 +340,12 @@ public class CustomRepairManager implements Listener {
 
         if (!hasFunds) {
             lore.add(Component.text("You need: " + formatCurrency(totalCost), NamedTextColor.RED));
-            inventory.setItem(1, createInfoItem(Component.text("Insufficient funds", NamedTextColor.RED), lore));
-            event.setResult(null);
+            inventory.setItem(INFO_SLOT, createInfoItem(Component.text("Insufficient funds", NamedTextColor.RED), lore, Material.RED_DYE));
             return;
         }
 
         lore.add(Component.text("Price: " + formatCurrency(totalCost), NamedTextColor.GREEN));
-        lore.add(Component.text("Take the result to repair", NamedTextColor.YELLOW));
+        lore.add(Component.text("Click the repaired item to confirm", NamedTextColor.YELLOW));
 
         ItemStack result = input.clone();
         ItemMeta meta = result.getItemMeta();
@@ -180,137 +355,73 @@ public class CustomRepairManager implements Listener {
         result.setItemMeta(meta);
 
         session.setResultItem(result);
-        inventory.setItem(1, createInfoItem(Component.text("Cost: " + formatCurrency(totalCost), NamedTextColor.GREEN), lore));
-        event.setResult(result);
+        inventory.setItem(INFO_SLOT, createInfoItem(Component.text("Cost: " + formatCurrency(totalCost), NamedTextColor.GREEN), lore, Material.EMERALD));
+        inventory.setItem(RESULT_SLOT, createResultDisplay(result, totalCost));
     }
 
-    @EventHandler
-    public void onInventoryClick(InventoryClickEvent event) {
-        InventoryView view = event.getView();
-        if (!menuTitle.equals(view.title())) {
-            return;
+    private ItemStack createResultDisplay(ItemStack base, double cost) {
+        ItemStack display = base.clone();
+        ItemMeta meta = display.getItemMeta();
+        List<Component> lore = meta.lore() != null ? new ArrayList<>(meta.lore()) : new ArrayList<>();
+        if (!lore.isEmpty()) {
+            lore.add(Component.empty());
         }
-
-        if (!(view.getTopInventory() instanceof AnvilInventory topInventory)) {
-            return;
-        }
-        if (!(event.getWhoClicked() instanceof Player player)) {
-            return;
-        }
-        AnvilInventory anvilInventory = topInventory;
-        RepairSession session = sessions.get(player.getUniqueId());
-        if (session == null) {
-            event.setCancelled(true);
-            return;
-        }
-
-        int rawSlot = event.getRawSlot();
-        if (rawSlot == 1) {
-            event.setCancelled(true);
-            return;
-        }
-
-        if (rawSlot == 2) {
-            event.setCancelled(true);
-            if (!session.isReady()) {
-                if (!session.isItemPresent()) {
-                    player.sendMessage(Component.text("Place an item in the first slot to repair it.", NamedTextColor.YELLOW));
-                } else if (!session.isRepairable()) {
-                    player.sendMessage(Component.text("That item cannot be repaired.", NamedTextColor.RED));
-                } else if (session.isAlreadyRepaired()) {
-                    player.sendMessage(Component.text("That item is already fully repaired.", NamedTextColor.GREEN));
-                } else if (!session.isAffordable()) {
-                    player.sendMessage(Component.text("You do not have enough money to repair this item.", NamedTextColor.RED));
-                }
-                return;
-            }
-
-            double cost = session.getCost();
-            if (!economy.has(player, cost)) {
-                player.sendMessage(Component.text("You no longer have enough money to repair this item.", NamedTextColor.RED));
-                session.setAffordable(false);
-                anvilInventory.setItem(2, null);
-                anvilInventory.setItem(1, createInfoItem(Component.text("Insufficient funds", NamedTextColor.RED), List.of()));
-                return;
-            }
-
-            EconomyResponse response = economy.withdrawPlayer(player, cost);
-            if (!response.transactionSuccess()) {
-                player.sendMessage(Component.text("The transaction failed: " + response.errorMessage, NamedTextColor.RED));
-                return;
-            }
-
-            ItemStack result = session.getResultItem().clone();
-            if (event.isShiftClick()) {
-                Map<Integer, ItemStack> remaining = player.getInventory().addItem(result);
-                remaining.values().forEach(item -> player.getWorld().dropItemNaturally(player.getLocation(), item));
-            } else {
-                ItemStack cursor = event.getCursor();
-                if (cursor == null || cursor.getType().isAir()) {
-                    event.getView().setCursor(result);
-                } else {
-                    Map<Integer, ItemStack> remaining = player.getInventory().addItem(result);
-                    remaining.values().forEach(item -> player.getWorld().dropItemNaturally(player.getLocation(), item));
-                }
-            }
-
-            anvilInventory.setItem(0, null);
-            anvilInventory.setItem(2, null);
-            anvilInventory.setItem(1, createInfoItem(Component.text("Insert an item to repair", NamedTextColor.YELLOW), List.of()));
-            session.reset();
-            player.sendMessage(Component.text("Paid " + formatCurrency(cost) + " to repair your item.", NamedTextColor.GOLD));
-            return;
-        }
-
-        if (event.getClickedInventory() == topInventory && event.isShiftClick()) {
-            event.setCancelled(true);
-        }
+        lore.add(Component.text("Repair Cost: " + formatCurrency(cost), NamedTextColor.GOLD));
+        lore.add(Component.text("Click to repair", NamedTextColor.YELLOW));
+        meta.lore(lore);
+        display.setItemMeta(meta);
+        return display;
     }
 
-    @EventHandler
-    public void onInventoryDrag(InventoryDragEvent event) {
-        InventoryView view = event.getView();
-        if (!menuTitle.equals(view.title())) {
-            return;
-        }
-
-        if (!(view.getTopInventory() instanceof AnvilInventory)) {
-            return;
-        }
-
-        for (int slot : event.getRawSlots()) {
-            if (slot == 1 || slot == 2) {
-                event.setCancelled(true);
-                return;
+    private void fillMenuLayout(Inventory inventory) {
+        for (int i = 0; i < inventory.getSize(); i++) {
+            if (i == INPUT_SLOT || i == INFO_SLOT || i == RESULT_SLOT) {
+                continue;
             }
+            inventory.setItem(i, fillerItem.clone());
         }
+        inventory.setItem(INFO_SLOT, createInfoItem(Component.text("Insert an item to repair", NamedTextColor.YELLOW), List.of(), Material.PAPER));
     }
 
-    @EventHandler
-    public void onInventoryClose(InventoryCloseEvent event) {
-        InventoryView view = event.getView();
-        if (!menuTitle.equals(view.title())) {
-            return;
-        }
-
-        if (!(view.getTopInventory() instanceof AnvilInventory inventory)) {
-            return;
-        }
-        inventory.setItem(1, null);
-        sessions.remove(event.getPlayer().getUniqueId());
-    }
-
-    private ItemStack createInfoItem(Component title, List<Component> lore) {
-        ItemStack item = new ItemStack(Material.PAPER);
+    private ItemStack createInfoItem(Component title, List<Component> lore, Material material) {
+        ItemStack item = new ItemStack(material);
         ItemMeta meta = item.getItemMeta();
         meta.displayName(title);
-        if (!lore.isEmpty()) {
-            meta.lore(lore);
-        } else {
+        if (lore.isEmpty()) {
             meta.lore(null);
+        } else {
+            meta.lore(lore);
         }
         item.setItemMeta(meta);
         return item;
+    }
+
+    private ItemStack createFillerItem() {
+        ItemStack item = new ItemStack(Material.GRAY_STAINED_GLASS_PANE);
+        ItemMeta meta = item.getItemMeta();
+        meta.displayName(Component.text(" ", NamedTextColor.GRAY));
+        meta.lore(null);
+        item.setItemMeta(meta);
+        return item;
+    }
+
+    private void returnItems(Player player, RepairSession session) {
+        Inventory inventory = session.getInventory();
+        ItemStack input = inventory.getItem(INPUT_SLOT);
+        ItemStack result = inventory.getItem(RESULT_SLOT);
+        inventory.setItem(INPUT_SLOT, null);
+        inventory.setItem(RESULT_SLOT, null);
+        inventory.setItem(INFO_SLOT, null);
+        session.clearState();
+
+        Map<Integer, ItemStack> overflow = new HashMap<>();
+        if (input != null && !input.getType().isAir()) {
+            overflow.putAll(player.getInventory().addItem(input));
+        }
+        if (result != null && !result.getType().isAir()) {
+            overflow.putAll(player.getInventory().addItem(result));
+        }
+        overflow.values().forEach(item -> player.getWorld().dropItemNaturally(player.getLocation(), item));
     }
 
     private String formatCurrency(double amount) {
@@ -331,6 +442,7 @@ public class CustomRepairManager implements Listener {
     }
 
     private static class RepairSession {
+        private final Inventory inventory;
         private double cost;
         private ItemStack resultItem;
         private boolean affordable;
@@ -338,7 +450,15 @@ public class CustomRepairManager implements Listener {
         private boolean repairable = true;
         private boolean alreadyRepaired;
 
-        public void reset() {
+        private RepairSession(Inventory inventory) {
+            this.inventory = inventory;
+        }
+
+        public Inventory getInventory() {
+            return inventory;
+        }
+
+        public void clearState() {
             cost = 0D;
             resultItem = null;
             affordable = false;
@@ -398,6 +518,5 @@ public class CustomRepairManager implements Listener {
         public void setAlreadyRepaired(boolean alreadyRepaired) {
             this.alreadyRepaired = alreadyRepaired;
         }
-
     }
 }


### PR DESCRIPTION
## Summary
- replace the anvil-based custom repair menu with a styled 3-row chest UI that highlights input, cost display, and output slots
- recalculate repair pricing when damaged items are inserted, only allowing removal of the player's item or the repaired result
- handle payment, result delivery, and automatic cleanup/return of items when the menu closes or is reopened

## Testing
- bash gradlew build *(fails: dependency repositories return 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68e0ed6d986c832b88cf2e69fed86185