### PR TITLE
Block anvil item combinations

### DIFF
--- a/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/Blockers/BlockersListener.java
+++ b/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/Blockers/BlockersListener.java
@@ -15,6 +15,7 @@ import org.bukkit.event.entity.*;
 import org.bukkit.event.inventory.InventoryMoveItemEvent;
 import org.bukkit.event.inventory.InventoryPickupItemEvent;
 import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.event.inventory.PrepareAnvilEvent;
 import org.bukkit.event.inventory.PrepareItemCraftEvent;
 import org.bukkit.event.player.PlayerFishEvent;
 import org.bukkit.event.player.PlayerItemConsumeEvent;
@@ -191,6 +192,15 @@ public class BlockersListener implements Listener {
     public void onHopperPickup(InventoryPickupItemEvent event) {
         if (event.getInventory().getType() == InventoryType.HOPPER) {
             event.setCancelled(true);
+        }
+    }
+
+    @EventHandler
+    public void onPrepareAnvil(PrepareAnvilEvent event) {
+        ItemStack rightInput = event.getInventory().getItem(1);
+        if (rightInput != null && rightInput.getType() != Material.AIR) {
+            event.setResult(new ItemStack(Material.AIR));
+            event.getInventory().setRepairCost(0);
         }
     }
 


### PR DESCRIPTION
## Summary
- prevent anvils from combining or repairing items while preserving rename functionality by clearing the result when the second slot is filled

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e0f479fe74832ba67bff44352abb4b