### PR TITLE
Add custom coin model to repair info display

### DIFF
--- a/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/CustomRepair/CustomRepairManager.java
+++ b/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/CustomRepair/CustomRepairManager.java
@@ -38,6 +38,7 @@ public class CustomRepairManager implements Listener {
     private static final int INVENTORY_SIZE = 27;
     private static final int INPUT_SLOT = 10;
     private static final int INFO_SLOT = 13;
+    private static final NamespacedKey COIN_MODEL_KEY = NamespacedKey.fromString("elytria:coin");
     private static final int RESULT_SLOT = 16;
 
     private final ElytriaEssentials plugin;
@@ -390,6 +391,9 @@ public class CustomRepairManager implements Listener {
             meta.lore(null);
         } else {
             meta.lore(lore);
+        }
+        if (COIN_MODEL_KEY != null && (material == Material.PAPER || material == Material.EMERALD)) {
+            meta.setItemModel(COIN_MODEL_KEY);
         }
         item.setItemMeta(meta);
         return item;


### PR DESCRIPTION
## Summary
- add a reusable namespaced key for the elytria coin item model
- apply the coin model to the repair menu info slot when displaying paper or emerald items

## Testing
- not run (unable to download dependencies in the container environment)


------
https://chatgpt.com/codex/tasks/task_e_68e13fc421d8832bac67bbaf7d0562fe