### PR TITLE
Add random information broadcast feature

### DIFF
--- a/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/ElytriaEssentials.java
+++ b/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/ElytriaEssentials.java
@@ -20,6 +20,7 @@ import java.io.File;
 
 import me.luisgamedev.elytriaEssentials.Blockers.BlockersListener;
 import me.luisgamedev.elytriaEssentials.RuneController.RuneController;
+import me.luisgamedev.elytriaEssentials.RandomInformation.RandomInformationManager;
 
 public final class ElytriaEssentials extends JavaPlugin {
 
@@ -29,6 +30,7 @@ public final class ElytriaEssentials extends JavaPlugin {
 
     private Economy economy;
     private RuneController runeController;
+    private RandomInformationManager randomInformationManager;
 
     @Override
     public void onEnable() {
@@ -74,6 +76,14 @@ public final class ElytriaEssentials extends JavaPlugin {
         } else {
             getLogger().warning("WGRegionEvents plugin not found. Custom music will be disabled.");
         }
+
+        randomInformationManager = new RandomInformationManager(this);
+        long intervalSeconds = getConfig().getLong("random-information.interval-seconds", 600L);
+        if (intervalSeconds > 0) {
+            randomInformationManager.start(intervalSeconds * 20L);
+        } else {
+            getLogger().warning("Random Information feature disabled because interval is not greater than zero.");
+        }
     }
 
     @Override
@@ -81,6 +91,10 @@ public final class ElytriaEssentials extends JavaPlugin {
         if (musicManager != null) {
             musicManager.shutdown();
             musicManager = null;
+        }
+        if (randomInformationManager != null) {
+            randomInformationManager.stop();
+            randomInformationManager = null;
         }
         economy = null;
         runeController = null;

--- a/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/RandomInformation/RandomInformationManager.java
+++ b/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/RandomInformation/RandomInformationManager.java
@@ -1,0 +1,104 @@
+package me.luisgamedev.elytriaEssentials.RandomInformation;
+
+import me.luisgamedev.elytriaEssentials.ElytriaEssentials;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.scheduler.BukkitTask;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+
+public class RandomInformationManager implements Runnable {
+
+    private final ElytriaEssentials plugin;
+    private final List<String> messages = new ArrayList<>();
+    private final Random random = new Random();
+
+    private List<String> shuffledMessages = new ArrayList<>();
+    private int nextIndex = 0;
+    private BukkitTask task;
+
+    public RandomInformationManager(ElytriaEssentials plugin) {
+        this.plugin = plugin;
+        loadMessages();
+    }
+
+    private void loadMessages() {
+        File infoFile = new File(plugin.getDataFolder(), "information.yml");
+        if (!infoFile.exists()) {
+            plugin.saveResource("information.yml", false);
+        }
+
+        FileConfiguration infoConfig = YamlConfiguration.loadConfiguration(infoFile);
+        List<String> loadedMessages = infoConfig.getStringList("information");
+
+        messages.clear();
+        for (String message : loadedMessages) {
+            if (message != null && !message.trim().isEmpty()) {
+                messages.add(message);
+            }
+        }
+
+        if (messages.isEmpty()) {
+            plugin.getLogger().warning("No informational messages found in information.yml. Random Information feature disabled.");
+        }
+
+        resetShuffle();
+    }
+
+    private void resetShuffle() {
+        if (messages.isEmpty()) {
+            shuffledMessages = Collections.emptyList();
+            nextIndex = 0;
+            return;
+        }
+
+        shuffledMessages = new ArrayList<>(messages);
+        Collections.shuffle(shuffledMessages, random);
+        nextIndex = 0;
+    }
+
+    public void start(long intervalTicks) {
+        stop();
+
+        if (messages.isEmpty()) {
+            return;
+        }
+
+        if (intervalTicks <= 0) {
+            plugin.getLogger().warning("Random Information interval must be greater than zero.");
+            return;
+        }
+
+        task = Bukkit.getScheduler().runTaskTimer(plugin, this, intervalTicks, intervalTicks);
+    }
+
+    public void stop() {
+        if (task != null) {
+            task.cancel();
+            task = null;
+        }
+    }
+
+    @Override
+    public void run() {
+        if (shuffledMessages.isEmpty()) {
+            return;
+        }
+
+        if (nextIndex >= shuffledMessages.size()) {
+            resetShuffle();
+            if (shuffledMessages.isEmpty()) {
+                return;
+            }
+        }
+
+        String message = shuffledMessages.get(nextIndex++);
+        Bukkit.broadcastMessage(ChatColor.translateAlternateColorCodes('&', message));
+    }
+}

--- a/Elytria Essentials/src/main/resources/config.yml
+++ b/Elytria Essentials/src/main/resources/config.yml
@@ -66,5 +66,9 @@ custom-repair:
   cost-growth-factor: 1.5
   npcs: [11]
 
+# Random Information
+random-information:
+  interval-seconds: 600
+
 
 

--- a/Elytria Essentials/src/main/resources/information.yml
+++ b/Elytria Essentials/src/main/resources/information.yml
@@ -1,0 +1,4 @@
+information:
+  - "&aRemember to vote daily to support the server and earn rewards!"
+  - "&bJoin our Discord to stay updated on events and announcements."
+  - "&eNeed help? Ask a staff member or type &6/help &efor a list of commands."


### PR DESCRIPTION
## Summary
- add a RandomInformationManager that shuffles predefined messages and broadcasts them on a schedule
- load a default information.yml and expose an interval-seconds option in config.yml

## Testing
- bash ./gradlew test *(fails: unable to download dependencies from external Maven repositories, HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68e15a5603dc832ba28b2989f1dc8713