### PR TITLE
Fix infinite loop when opening custom rename anvil

### DIFF
--- a/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/AnvilRename/CustomRenameListener.java
+++ b/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/AnvilRename/CustomRenameListener.java
@@ -70,15 +70,13 @@ public class CustomRenameListener implements Listener {
 
         AnvilInventory inventory = event.getInventory();
         inventory.setRepairCost(0);
+        schedulePlaceholderRefresh(inventory);
 
         ItemStack leftInput = inventory.getItem(0);
         if (leftInput == null || leftInput.getType().isAir()) {
-            clearPlaceholder(inventory);
             event.setResult(null);
             return;
         }
-
-        inventory.setItem(1, createPriceDisplay());
 
         String renameText = inventory.getRenameText();
         if (renameText == null || renameText.isBlank()) {
@@ -230,7 +228,7 @@ public class CustomRenameListener implements Listener {
         ItemStack leftInput = inventory.getItem(0);
         if (leftInput == null || leftInput.getType().isAir()) {
             clearPlaceholder(inventory);
-        } else {
+        } else if (!isPriceDisplay(inventory.getItem(1))) {
             inventory.setItem(1, createPriceDisplay());
         }
         inventory.setRepairCost(0);


### PR DESCRIPTION
## Summary
- schedule the price placeholder update so the anvil prepare event does not recurse
- avoid resetting the price item when it is already present to prevent redundant events

## Testing
- `bash ./gradlew build` *(fails: remote Maven repositories return 403 responses in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e169817f74832b87ae6d3c3996f2f6