### PR TITLE
Restrict block breaking in elytria_prison and auto-collect coal blocks

### DIFF
--- a/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/Coalmine/CoalmineManager.java
+++ b/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/Coalmine/CoalmineManager.java
@@ -10,6 +10,7 @@ import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.inventory.CraftItemEvent;
 import org.bukkit.event.player.PlayerChangedWorldEvent;
@@ -209,6 +210,22 @@ public class CoalmineManager implements Listener {
         if (isInCoalmineWorld(event.getEntity())) {
             event.getDrops().clear();
         }
+    }
+
+    @EventHandler
+    public void onBlockBreak(BlockBreakEvent event) {
+        Player player = event.getPlayer();
+        if (!isInCoalmineWorld(player)) {
+            return;
+        }
+
+        if (event.getBlock().getType() != Material.COAL_BLOCK) {
+            event.setCancelled(true);
+            return;
+        }
+
+        event.setDropItems(false);
+        player.getInventory().addItem(new ItemStack(Material.COAL_BLOCK));
     }
 
     private void startFatigueTask() {


### PR DESCRIPTION
### Motivation
- Ensure the coalmine world `elytria_prison` is restricted so players cannot break anything except coal blocks, and collect mined coal blocks directly into the player's inventory to avoid world drops and item loss.

### Description
- Added an `onBlockBreak(BlockBreakEvent)` handler in `CoalmineManager` that returns early when the player is not in the coalmine world and cancels any break where the block type is not `Material.COAL_BLOCK`.
- When a `COAL_BLOCK` is broken in `elytria_prison`, the handler calls `event.setDropItems(false)` and immediately adds a new `ItemStack(Material.COAL_BLOCK)` to the breaker’s inventory.
- Added the `org.bukkit.event.block.BlockBreakEvent` import and updated `CoalmineManager.java` accordingly.

### Testing
- Ran `./gradlew compileJava` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c79ce2bf04832b8d06a648ad4380d2)