### PR TITLE
Add MMOCore-based `partyname` placeholder

### DIFF
--- a/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/ClanSystem/Placeholders/RegisterPlaceholders.java
+++ b/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/ClanSystem/Placeholders/RegisterPlaceholders.java
@@ -6,6 +6,8 @@ import me.luisgamedev.elytriaEssentials.ClanSystem.ClanManager;
 import me.luisgamedev.elytriaEssentials.ElytriaEssentials;
 import net.Indyuce.mmocore.MMOCore;
 import net.Indyuce.mmocore.api.player.PlayerData;
+import net.Indyuce.mmocore.party.AbstractParty;
+import net.Indyuce.mmocore.party.provided.Party;
 import net.Indyuce.mmocore.api.player.profess.PlayerClass;
 import net.Indyuce.mmocore.api.player.profess.SavedClassInformation;
 import net.Indyuce.mmoitems.MMOItems;
@@ -118,7 +120,36 @@ public class RegisterPlaceholders extends PlaceholderExpansion {
         if (params.equalsIgnoreCase("weapon_level")) {
             return getHighestUsableClassWeaponLevel(player).orElse("0.3");
         }
+        if (params.equalsIgnoreCase("partyname")) {
+            return resolveBuiltInPartyOwner(player);
+        }
         return null;
+    }
+
+    private String resolveBuiltInPartyOwner(Player player) {
+        String playerUuid = player.getUniqueId().toString();
+        String missingPartyValue = playerUuid.substring(0, Math.min(8, playerUuid.length())) + "-null";
+
+        if (!Bukkit.getPluginManager().isPluginEnabled("MMOCore") || !PlayerData.has(player)) {
+            return missingPartyValue;
+        }
+
+        PlayerData playerData = PlayerData.get(player);
+        if (playerData == null) {
+            return missingPartyValue;
+        }
+
+        AbstractParty party = playerData.getParty();
+        if (!(party instanceof Party builtInParty)) {
+            return missingPartyValue;
+        }
+
+        PlayerData owner = builtInParty.getOwner();
+        if (owner == null) {
+            return missingPartyValue;
+        }
+
+        return owner.getUniqueId().toString();
     }
 
     private boolean isLookingAtLivingEntity(Player player) {


### PR DESCRIPTION
### Motivation
- Expose a new `%elytria_partyname%` placeholder that queries MMOCore for the player's built-in party and returns the party owner's UUID or a deterministic fallback when no built-in party/owner is available.

### Description
- Added imports for `net.Indyuce.mmocore.party.AbstractParty` and `net.Indyuce.mmocore.party.provided.Party`, added a `partyname` branch to `onPlaceholderRequest` in `RegisterPlaceholders.java`, and implemented `resolveBuiltInPartyOwner(Player)` which reads `PlayerData.getParty()`, verifies it's a built-in `Party`, returns the owner's `UUID` string, and otherwise returns the first 8 characters of the player's UUID plus `-null`.

### Testing
- Ran `./gradlew compileJava` in `Elytria Essentials/` and the project compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da3af370e0832b9ca4ad670c5c38d6)