### PR TITLE
Add new `%text_%` PlaceholderAPI expansion with font suffix support

### DIFF
--- a/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/ElytriaEssentials.java
+++ b/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/ElytriaEssentials.java
@@ -42,6 +42,7 @@ import me.luisgamedev.elytriaEssentials.commands.PartyCommand;
 import me.luisgamedev.elytriaEssentials.commands.HologramCommand;
 import me.luisgamedev.elytriaEssentials.Soulbinding.SoulbindingManager;
 import me.luisgamedev.elytriaEssentials.MMOCore.PartyIntegrationManager;
+import me.luisgamedev.elytriaEssentials.Placeholders.TextPlaceholderExpansion;
 import me.luisgamedev.elytriaEssentials.Regeneration.CustomRegenerationManager;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -96,6 +97,7 @@ public final class ElytriaEssentials extends JavaPlugin {
     private NextJoinItemManager nextJoinItemManager;
     private CustomRegenerationManager customRegenerationManager;
     private CoalmineManager coalmineManager;
+    private TextPlaceholderExpansion textPlaceholderExpansion;
 
     @Override
     public void onEnable() {
@@ -117,6 +119,9 @@ public final class ElytriaEssentials extends JavaPlugin {
         registerSpawnCommand("discordlink", spawnCommandHandler);
         if (!new File(getDataFolder(), "exp-rewards.yml").exists()) {
             saveResource("exp-rewards.yml", false);
+        }
+        if (!new File(getDataFolder(), "texts.yml").exists()) {
+            saveResource("texts.yml", false);
         }
         ArrowSkillHandler arrowSkillHandler = new ArrowSkillHandler(this);
         pm.registerEvents(arrowSkillHandler, this);
@@ -224,6 +229,8 @@ public final class ElytriaEssentials extends JavaPlugin {
 
         if (Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI")) {
             new RegisterPlaceholders(this, clanManager).register();
+            textPlaceholderExpansion = new TextPlaceholderExpansion(this);
+            textPlaceholderExpansion.register();
             if (Bukkit.getPluginManager().isPluginEnabled("MMOCore")) {
                 new RegisterPlaceholders.MMOClassPlaceholders(this).register();
             } else {

--- a/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/Placeholders/TextPlaceholderExpansion.java
+++ b/Elytria Essentials/src/main/java/me/luisgamedev/elytriaEssentials/Placeholders/TextPlaceholderExpansion.java
@@ -1,0 +1,108 @@
+package me.luisgamedev.elytriaEssentials.Placeholders;
+
+import me.clip.placeholderapi.expansion.PlaceholderExpansion;
+import me.luisgamedev.elytriaEssentials.ElytriaEssentials;
+import org.bukkit.ChatColor;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.Player;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class TextPlaceholderExpansion extends PlaceholderExpansion {
+
+    private final ElytriaEssentials plugin;
+    private final Map<String, String> textCache = new ConcurrentHashMap<>();
+
+    public TextPlaceholderExpansion(ElytriaEssentials plugin) {
+        this.plugin = plugin;
+        loadTexts();
+    }
+
+    public final void loadTexts() {
+        textCache.clear();
+
+        File textsFile = new File(plugin.getDataFolder(), "texts.yml");
+        if (!textsFile.exists()) {
+            plugin.saveResource("texts.yml", false);
+        }
+
+        YamlConfiguration configuration = YamlConfiguration.loadConfiguration(textsFile);
+        ConfigurationSection textSection = configuration.getConfigurationSection("texts");
+        if (textSection == null) {
+            plugin.getLogger().warning("texts.yml is missing the 'texts' section. No %text_% placeholders will resolve.");
+            return;
+        }
+
+        for (String key : textSection.getKeys(false)) {
+            String combinedText = readCombinedText(textSection, key);
+            if (combinedText != null && !combinedText.isEmpty()) {
+                textCache.put(key.toLowerCase(Locale.ROOT), combinedText);
+            }
+        }
+    }
+
+    @Override
+    public String getIdentifier() {
+        return "text";
+    }
+
+    @Override
+    public String getAuthor() {
+        return plugin.getDescription().getAuthors().isEmpty() ? "" : plugin.getDescription().getAuthors().get(0);
+    }
+
+    @Override
+    public String getVersion() {
+        return plugin.getDescription().getVersion();
+    }
+
+    @Override
+    public String onPlaceholderRequest(Player player, String params) {
+        if (params == null || params.isEmpty()) {
+            return "";
+        }
+
+        int lastUnderscore = params.lastIndexOf('_');
+        if (lastUnderscore <= 0 || lastUnderscore == params.length() - 1) {
+            return "";
+        }
+
+        String textIdentifier = params.substring(0, lastUnderscore).toLowerCase(Locale.ROOT);
+        String font = params.substring(lastUnderscore + 1).toLowerCase(Locale.ROOT);
+
+        String text = textCache.get(textIdentifier);
+        if (text == null) {
+            return "";
+        }
+
+        String fontTag = "<font:elytria:" + font + ">";
+        return fontTag + ChatColor.translateAlternateColorCodes('&', text) + "</font>";
+    }
+
+    private String readCombinedText(ConfigurationSection textSection, String key) {
+        Object value = textSection.get(key);
+
+        if (value instanceof String stringValue) {
+            return stringValue;
+        }
+
+        if (value instanceof List<?> listValue) {
+            List<String> parts = new ArrayList<>();
+            for (Object element : listValue) {
+                if (element == null) {
+                    continue;
+                }
+                parts.add(String.valueOf(element));
+            }
+            return String.join("", parts);
+        }
+
+        return null;
+    }
+}

--- a/Elytria Essentials/src/main/resources/texts.yml
+++ b/Elytria Essentials/src/main/resources/texts.yml
@@ -1,0 +1,18 @@
+# Placeholder format:
+# %text_<text_identifier>_<font>%
+#
+# Examples:
+# %text_rulebooktext_oldgerman%
+# %text_quest_npc_alfred_story_3_newenglish%
+#
+# The first part is always the PlaceholderAPI identifier: text
+# The last part is always the font, applied as <font:elytria:<font>>...</font>
+texts:
+  rulebooktext:
+    - "&7[ "
+    - "&fThe old laws remain in effect."
+    - "&7 ]"
+
+  quest_npc_alfred_story_3:
+    - "&eAlfred: "
+    - "&fThe mist grew thicker as we crossed the valley."


### PR DESCRIPTION
### Motivation
- Provide a dedicated, separate PlaceholderAPI expansion to serve configurable multi-line texts and apply a custom font namespace per-placeholder.
- Allow content authors to manage large or structured text blocks in `texts.yml` instead of embedding long strings in code or other placeholder classes.
- Support the requested placeholder format where the final underscore segment is the font key to apply.

### Description
- Added `TextPlaceholderExpansion` (`me.luisgamedev.elytriaEssentials.Placeholders.TextPlaceholderExpansion`) which registers under the identifier `text` and parses placeholders by taking everything before the last `_` as the text key and the final segment as the font key.
- Loads texts from a new `texts.yml` resource under the `texts:` section and accepts either a single string or a list of strings (which are concatenated in order) when building the resolved text.
- Wraps resolved text with a font tag using the `elytria` namespace (returns `<font:elytria:<font>>...</font>`) and translates `&` color codes via `ChatColor.translateAlternateColorCodes('&', ...)`.
- Wired startup integration in `ElytriaEssentials` to auto-create `texts.yml` if missing and register the new expansion when `PlaceholderAPI` is present.

### Testing
- Ran `./gradlew compileJava` in the plugin module which completed successfully (BUILD SUCCESSFUL).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd071f98d8832bbbf3e76908e02111)